### PR TITLE
chore: remove unused logger

### DIFF
--- a/lib/langfuse_sdk/support/client.ex
+++ b/lib/langfuse_sdk/support/client.ex
@@ -4,7 +4,6 @@ defmodule LangfuseSdk.Support.Client do
   This module contains request client used by the generated operations.
   """
 
-  require Logger
   alias LangfuseSdk.Support.Auth
   alias LangfuseSdk.Support.Translator
 
@@ -44,18 +43,14 @@ defmodule LangfuseSdk.Support.Client do
   end
 
   defp execute_request(%{method: :post} = opts) do
-    request =
-      [
-        url: build_endpoint(opts.url),
-        body: encode_body(opts[:body]),
-        retry: :transient
-      ]
-      |> Req.new()
-      |> Auth.put_auth_headers()
-      |> Req.post()
-
-    Logger.info("[LangfuseSdk] Request: #{inspect(request)}")
-    request
+    [
+      url: build_endpoint(opts.url),
+      body: encode_body(opts[:body]),
+      retry: :transient
+    ]
+    |> Req.new()
+    |> Auth.put_auth_headers()
+    |> Req.post()
   end
 
   # Helper function to build the URL


### PR DESCRIPTION
We introduced this log statement to inspect failures responses returned by Langfuse server. Now it is not needed anymore.