### PR TITLE
fix: return list of %LangfuseSdk.Generated.Project{}

### DIFF
--- a/lib/langfuse_sdk.ex
+++ b/lib/langfuse_sdk.ex
@@ -152,6 +152,7 @@ defmodule LangfuseSdk do
 
   """
   def get_projects() do
-    LangfuseSdk.Generated.Projects.projects_get()
+    result = LangfuseSdk.Generated.Projects.projects_get()
+    with {:ok, body} <- result, do: {:ok, Map.fetch!(body, :data)}
   end
 end

--- a/lib/langfuse_sdk.ex
+++ b/lib/langfuse_sdk.ex
@@ -143,15 +143,15 @@ defmodule LangfuseSdk do
   end
 
   @doc """
-  Get Project associated with API key
+  Get Projects associated with API key
 
   ## Example
 
-    LangfuseSdk.get_projects()
+    LangfuseSdk.list_projects()
     {:ok, [%LangfuseSdk.Generated.Project{}]}
 
   """
-  def get_projects() do
+  def list_projects() do
     result = LangfuseSdk.Generated.Projects.projects_get()
     with {:ok, body} <- result, do: {:ok, Map.fetch!(body, :data)}
   end


### PR DESCRIPTION
projects_get return a data object %LangfuseSdk.Generated.Projects{}.

to match the `list_traces` endpoint fetch the `data` inside and return the list of `%LangfuseSdk.Generated.Project{}`