### PR TITLE
feat: add image support for langfuse generations [sc-58099]

### DIFF
--- a/lib/langfuse_sdk.ex
+++ b/lib/langfuse_sdk.ex
@@ -44,7 +44,6 @@ defmodule LangfuseSdk do
 
   def create(%LangfuseSdk.Tracing.Generation{} = generation) do
     updated_generation = LangfuseSdk.Support.Media.replace_image_urls(generation)
-    dbg(updated_generation)
     generation_event = LangfuseSdk.Ingestor.to_event(updated_generation, :create)
     LangfuseSdk.Ingestor.ingest_payload(generation_event)
   end

--- a/lib/langfuse_sdk.ex
+++ b/lib/langfuse_sdk.ex
@@ -43,7 +43,9 @@ defmodule LangfuseSdk do
   end
 
   def create(%LangfuseSdk.Tracing.Generation{} = generation) do
-    generation_event = LangfuseSdk.Ingestor.to_event(generation, :create)
+    updated_generation = LangfuseSdk.Support.Media.replace_image_urls(generation)
+    dbg(updated_generation)
+    generation_event = LangfuseSdk.Ingestor.to_event(updated_generation, :create)
     LangfuseSdk.Ingestor.ingest_payload(generation_event)
   end
 

--- a/lib/langfuse_sdk/generated/operations/annotation_queues.ex
+++ b/lib/langfuse_sdk/generated/operations/annotation_queues.ex
@@ -1,0 +1,228 @@
+defmodule LangfuseSdk.Generated.AnnotationQueues do
+  @moduledoc """
+  Provides API endpoints related to annotation queues
+  """
+
+  @default_client LangfuseSdk.Support.Client
+
+  @doc """
+  post `/api/public/annotation-queues/{queueId}/items`
+
+  Add an item to an annotation queue
+  """
+  @spec annotation_queues_create_queue_item(
+          String.t(),
+          LangfuseSdk.Generated.CreateAnnotationQueueItemRequest.t(),
+          keyword
+        ) :: {:ok, LangfuseSdk.Generated.AnnotationQueueItem.t()} | {:error, map}
+  def annotation_queues_create_queue_item(queueId, body, opts \\ []) do
+    client = opts[:client] || @default_client
+
+    client.request(%{
+      args: [queueId: queueId, body: body],
+      call: {LangfuseSdk.Generated.AnnotationQueues, :annotation_queues_create_queue_item},
+      url: "/api/public/annotation-queues/#{queueId}/items",
+      body: body,
+      method: :post,
+      request: [
+        {"application/json", {LangfuseSdk.Generated.CreateAnnotationQueueItemRequest, :t}}
+      ],
+      response: [
+        {200, {LangfuseSdk.Generated.AnnotationQueueItem, :t}},
+        {400, :map},
+        {401, :map},
+        {403, :map},
+        {404, :map},
+        {405, :map}
+      ],
+      opts: opts
+    })
+  end
+
+  @doc """
+  delete `/api/public/annotation-queues/{queueId}/items/{itemId}`
+
+  Remove an item from an annotation queue
+  """
+  @spec annotation_queues_delete_queue_item(String.t(), String.t(), keyword) ::
+          {:ok, LangfuseSdk.Generated.DeleteAnnotationQueueItemResponse.t()} | {:error, map}
+  def annotation_queues_delete_queue_item(queueId, itemId, opts \\ []) do
+    client = opts[:client] || @default_client
+
+    client.request(%{
+      args: [queueId: queueId, itemId: itemId],
+      call: {LangfuseSdk.Generated.AnnotationQueues, :annotation_queues_delete_queue_item},
+      url: "/api/public/annotation-queues/#{queueId}/items/#{itemId}",
+      method: :delete,
+      response: [
+        {200, {LangfuseSdk.Generated.DeleteAnnotationQueueItemResponse, :t}},
+        {400, :map},
+        {401, :map},
+        {403, :map},
+        {404, :map},
+        {405, :map}
+      ],
+      opts: opts
+    })
+  end
+
+  @doc """
+  get `/api/public/annotation-queues/{queueId}`
+
+  Get an annotation queue by ID
+  """
+  @spec annotation_queues_get_queue(String.t(), keyword) ::
+          {:ok, LangfuseSdk.Generated.AnnotationQueue.t()} | {:error, map}
+  def annotation_queues_get_queue(queueId, opts \\ []) do
+    client = opts[:client] || @default_client
+
+    client.request(%{
+      args: [queueId: queueId],
+      call: {LangfuseSdk.Generated.AnnotationQueues, :annotation_queues_get_queue},
+      url: "/api/public/annotation-queues/#{queueId}",
+      method: :get,
+      response: [
+        {200, {LangfuseSdk.Generated.AnnotationQueue, :t}},
+        {400, :map},
+        {401, :map},
+        {403, :map},
+        {404, :map},
+        {405, :map}
+      ],
+      opts: opts
+    })
+  end
+
+  @doc """
+  get `/api/public/annotation-queues/{queueId}/items/{itemId}`
+
+  Get a specific item from an annotation queue
+  """
+  @spec annotation_queues_get_queue_item(String.t(), String.t(), keyword) ::
+          {:ok, LangfuseSdk.Generated.AnnotationQueueItem.t()} | {:error, map}
+  def annotation_queues_get_queue_item(queueId, itemId, opts \\ []) do
+    client = opts[:client] || @default_client
+
+    client.request(%{
+      args: [queueId: queueId, itemId: itemId],
+      call: {LangfuseSdk.Generated.AnnotationQueues, :annotation_queues_get_queue_item},
+      url: "/api/public/annotation-queues/#{queueId}/items/#{itemId}",
+      method: :get,
+      response: [
+        {200, {LangfuseSdk.Generated.AnnotationQueueItem, :t}},
+        {400, :map},
+        {401, :map},
+        {403, :map},
+        {404, :map},
+        {405, :map}
+      ],
+      opts: opts
+    })
+  end
+
+  @doc """
+  get `/api/public/annotation-queues/{queueId}/items`
+
+  Get items for a specific annotation queue
+
+  ## Options
+
+    * `status`: Filter by status
+    * `page`: page number, starts at 1
+    * `limit`: limit of items per page
+
+  """
+  @spec annotation_queues_list_queue_items(String.t(), keyword) ::
+          {:ok, LangfuseSdk.Generated.PaginatedAnnotationQueueItems.t()} | {:error, map}
+  def annotation_queues_list_queue_items(queueId, opts \\ []) do
+    client = opts[:client] || @default_client
+    query = Keyword.take(opts, [:limit, :page, :status])
+
+    client.request(%{
+      args: [queueId: queueId],
+      call: {LangfuseSdk.Generated.AnnotationQueues, :annotation_queues_list_queue_items},
+      url: "/api/public/annotation-queues/#{queueId}/items",
+      method: :get,
+      query: query,
+      response: [
+        {200, {LangfuseSdk.Generated.PaginatedAnnotationQueueItems, :t}},
+        {400, :map},
+        {401, :map},
+        {403, :map},
+        {404, :map},
+        {405, :map}
+      ],
+      opts: opts
+    })
+  end
+
+  @doc """
+  get `/api/public/annotation-queues`
+
+  Get all annotation queues
+
+  ## Options
+
+    * `page`: page number, starts at 1
+    * `limit`: limit of items per page
+
+  """
+  @spec annotation_queues_list_queues(keyword) ::
+          {:ok, LangfuseSdk.Generated.PaginatedAnnotationQueues.t()} | {:error, map}
+  def annotation_queues_list_queues(opts \\ []) do
+    client = opts[:client] || @default_client
+    query = Keyword.take(opts, [:limit, :page])
+
+    client.request(%{
+      args: [],
+      call: {LangfuseSdk.Generated.AnnotationQueues, :annotation_queues_list_queues},
+      url: "/api/public/annotation-queues",
+      method: :get,
+      query: query,
+      response: [
+        {200, {LangfuseSdk.Generated.PaginatedAnnotationQueues, :t}},
+        {400, :map},
+        {401, :map},
+        {403, :map},
+        {404, :map},
+        {405, :map}
+      ],
+      opts: opts
+    })
+  end
+
+  @doc """
+  patch `/api/public/annotation-queues/{queueId}/items/{itemId}`
+
+  Update an annotation queue item
+  """
+  @spec annotation_queues_update_queue_item(
+          String.t(),
+          String.t(),
+          LangfuseSdk.Generated.UpdateAnnotationQueueItemRequest.t(),
+          keyword
+        ) :: {:ok, LangfuseSdk.Generated.AnnotationQueueItem.t()} | {:error, map}
+  def annotation_queues_update_queue_item(queueId, itemId, body, opts \\ []) do
+    client = opts[:client] || @default_client
+
+    client.request(%{
+      args: [queueId: queueId, itemId: itemId, body: body],
+      call: {LangfuseSdk.Generated.AnnotationQueues, :annotation_queues_update_queue_item},
+      url: "/api/public/annotation-queues/#{queueId}/items/#{itemId}",
+      body: body,
+      method: :patch,
+      request: [
+        {"application/json", {LangfuseSdk.Generated.UpdateAnnotationQueueItemRequest, :t}}
+      ],
+      response: [
+        {200, {LangfuseSdk.Generated.AnnotationQueueItem, :t}},
+        {400, :map},
+        {401, :map},
+        {403, :map},
+        {404, :map},
+        {405, :map}
+      ],
+      opts: opts
+    })
+  end
+end

--- a/lib/langfuse_sdk/generated/operations/comments.ex
+++ b/lib/langfuse_sdk/generated/operations/comments.ex
@@ -1,0 +1,101 @@
+defmodule LangfuseSdk.Generated.Comments do
+  @moduledoc """
+  Provides API endpoints related to comments
+  """
+
+  @default_client LangfuseSdk.Support.Client
+
+  @doc """
+  post `/api/public/comments`
+
+  Create a comment. Comments may be attached to different object types (trace, observation, session, prompt).
+  """
+  @spec comments_create(LangfuseSdk.Generated.CreateCommentRequest.t(), keyword) ::
+          {:ok, LangfuseSdk.Generated.CreateCommentResponse.t()} | {:error, map}
+  def comments_create(body, opts \\ []) do
+    client = opts[:client] || @default_client
+
+    client.request(%{
+      args: [body: body],
+      call: {LangfuseSdk.Generated.Comments, :comments_create},
+      url: "/api/public/comments",
+      body: body,
+      method: :post,
+      request: [{"application/json", {LangfuseSdk.Generated.CreateCommentRequest, :t}}],
+      response: [
+        {200, {LangfuseSdk.Generated.CreateCommentResponse, :t}},
+        {400, :map},
+        {401, :map},
+        {403, :map},
+        {404, :map},
+        {405, :map}
+      ],
+      opts: opts
+    })
+  end
+
+  @doc """
+  get `/api/public/comments`
+
+  Get all comments
+
+  ## Options
+
+    * `page`: Page number, starts at 1.
+    * `limit`: Limit of items per page. If you encounter api issues due to too large page sizes, try to reduce the limit
+    * `objectType`: Filter comments by object type (trace, observation, session, prompt).
+    * `objectId`: Filter comments by object id. If objectType is not provided, an error will be thrown.
+    * `authorUserId`: Filter comments by author user id.
+
+  """
+  @spec comments_get(keyword) ::
+          {:ok, LangfuseSdk.Generated.GetCommentsResponse.t()} | {:error, map}
+  def comments_get(opts \\ []) do
+    client = opts[:client] || @default_client
+    query = Keyword.take(opts, [:authorUserId, :limit, :objectId, :objectType, :page])
+
+    client.request(%{
+      args: [],
+      call: {LangfuseSdk.Generated.Comments, :comments_get},
+      url: "/api/public/comments",
+      method: :get,
+      query: query,
+      response: [
+        {200, {LangfuseSdk.Generated.GetCommentsResponse, :t}},
+        {400, :map},
+        {401, :map},
+        {403, :map},
+        {404, :map},
+        {405, :map}
+      ],
+      opts: opts
+    })
+  end
+
+  @doc """
+  get `/api/public/comments/{commentId}`
+
+  Get a comment by id
+  """
+  @spec comments_get_by_id(String.t(), keyword) ::
+          {:ok, LangfuseSdk.Generated.Comment.t()} | {:error, map}
+  def comments_get_by_id(commentId, opts \\ []) do
+    client = opts[:client] || @default_client
+
+    client.request(%{
+      args: [commentId: commentId],
+      call: {LangfuseSdk.Generated.Comments, :comments_get_by_id},
+      url: "/api/public/comments/#{commentId}",
+      method: :get,
+      response: [
+        {200, {LangfuseSdk.Generated.Comment, :t}},
+        {400, :map},
+        {401, :map},
+        {403, :map},
+        {404, :map},
+        {405, :map}
+      ],
+      opts: opts
+    })
+  end
+end

--- a/lib/langfuse_sdk/generated/operations/dataset_items.ex
+++ b/lib/langfuse_sdk/generated/operations/dataset_items.ex
@@ -35,6 +35,33 @@ defmodule LangfuseSdk.Generated.DatasetItems do
   end
 
   @doc """
+  delete `/api/public/dataset-items/{id}`
+
+  Delete a dataset item and all its run items. This action is irreversible.
+  """
+  @spec dataset_items_delete(String.t(), keyword) ::
+          {:ok, LangfuseSdk.Generated.DeleteDatasetItemResponse.t()} | {:error, map}
+  def dataset_items_delete(id, opts \\ []) do
+    client = opts[:client] || @default_client
+
+    client.request(%{
+      args: [id: id],
+      call: {LangfuseSdk.Generated.DatasetItems, :dataset_items_delete},
+      url: "/api/public/dataset-items/#{id}",
+      method: :delete,
+      response: [
+        {200, {LangfuseSdk.Generated.DeleteDatasetItemResponse, :t}},
+        {400, :map},
+        {401, :map},
+        {403, :map},
+        {404, :map},
+        {405, :map}
+      ],
+      opts: opts
+    })
+  end
+
+  @doc """
   get `/api/public/dataset-items/{id}`
 
   Get a dataset item

--- a/lib/langfuse_sdk/generated/operations/datasets.ex
+++ b/lib/langfuse_sdk/generated/operations/datasets.ex
@@ -35,6 +35,33 @@ defmodule LangfuseSdk.Generated.Datasets do
   end
 
   @doc """
+  delete `/api/public/datasets/{datasetName}/runs/{runName}`
+
+  Delete a dataset run and all its run items. This action is irreversible.
+  """
+  @spec datasets_delete_run(String.t(), String.t(), keyword) ::
+          {:ok, LangfuseSdk.Generated.DeleteDatasetRunResponse.t()} | {:error, map}
+  def datasets_delete_run(datasetName, runName, opts \\ []) do
+    client = opts[:client] || @default_client
+
+    client.request(%{
+      args: [datasetName: datasetName, runName: runName],
+      call: {LangfuseSdk.Generated.Datasets, :datasets_delete_run},
+      url: "/api/public/datasets/#{datasetName}/runs/#{runName}",
+      method: :delete,
+      response: [
+        {200, {LangfuseSdk.Generated.DeleteDatasetRunResponse, :t}},
+        {400, :map},
+        {401, :map},
+        {403, :map},
+        {404, :map},
+        {405, :map}
+      ],
+      opts: opts
+    })
+  end
+
+  @doc """
   get `/api/public/v2/datasets/{datasetName}`
 
   Get a dataset

--- a/lib/langfuse_sdk/generated/operations/ingestion.ex
+++ b/lib/langfuse_sdk/generated/operations/ingestion.ex
@@ -8,10 +8,18 @@ defmodule LangfuseSdk.Generated.Ingestion do
   @doc """
   post `/api/public/ingestion`
 
-  Batched ingestion for Langfuse Tracing. If you want to use tracing via the API, such as to build your own Langfuse client implementation, this is the only API route you need to implement.
+  Batched ingestion for Langfuse Tracing.
+  If you want to use tracing via the API, such as to build your own Langfuse client implementation, this is the only API route you need to implement.
+
+  Within each batch, there can be multiple events.
+  Each event has a type, an id, a timestamp, metadata and a body.
+  Internally, we refer to this as the "event envelope" as it tells us something about the event but not the trace.
+  We use the event id within this envelope to deduplicate messages to avoid processing the same event twice, i.e. the event id should be unique per request.
+  The event.body.id is the ID of the actual trace and will be used for updates and will be visible within the Langfuse App.
+  I.e. if you want to update a trace, you'd use the same body id, but separate event IDs.
 
   Notes:
-
+  - Introduction to data model: https://langfuse.com/docs/tracing-data-model
   - Batch sizes are limited to 3.5 MB in total. You need to adjust the number of events per batch accordingly.
   - The API does not return a 4xx status code for input errors. Instead, it responds with a 207 status code, which includes a list of the encountered errors.
   """
@@ -28,7 +36,7 @@ defmodule LangfuseSdk.Generated.Ingestion do
       method: :post,
       request: [{"application/json", :map}],
       response: [
-        {200, {LangfuseSdk.Generated.IngestionResponse, :t}},
+        {201, {LangfuseSdk.Generated.IngestionResponse, :t}},
         {400, :map},
         {401, :map},
         {403, :map},

--- a/lib/langfuse_sdk/generated/operations/media.ex
+++ b/lib/langfuse_sdk/generated/operations/media.ex
@@ -1,0 +1,85 @@
+defmodule LangfuseSdk.Generated.Media do
+  @moduledoc """
+  Provides API endpoints related to media
+  """
+
+  @default_client LangfuseSdk.Support.Client
+
+  @doc """
+  get `/api/public/media/{mediaId}`
+
+  Get a media record
+  """
+  @spec media_get(String.t(), keyword) ::
+          {:ok, LangfuseSdk.Generated.GetMediaResponse.t()} | {:error, map}
+  def media_get(mediaId, opts \\ []) do
+    client = opts[:client] || @default_client
+
+    client.request(%{
+      args: [mediaId: mediaId],
+      call: {LangfuseSdk.Generated.Media, :media_get},
+      url: "/api/public/media/#{mediaId}",
+      method: :get,
+      response: [
+        {200, {LangfuseSdk.Generated.GetMediaResponse, :t}},
+        {400, :map},
+        {401, :map},
+        {403, :map},
+        {404, :map},
+        {405, :map}
+      ],
+      opts: opts
+    })
+  end
+
+  @doc """
+  post `/api/public/media`
+
+  Get a presigned upload URL for a media record
+  """
+  @spec media_get_upload_url(LangfuseSdk.Generated.GetMediaUploadUrlRequest.t(), keyword) ::
+          {:ok, LangfuseSdk.Generated.GetMediaUploadUrlResponse.t()} | {:error, map}
+  def media_get_upload_url(body, opts \\ []) do
+    client = opts[:client] || @default_client
+
+    client.request(%{
+      args: [body: body],
+      call: {LangfuseSdk.Generated.Media, :media_get_upload_url},
+      url: "/api/public/media",
+      body: body,
+      method: :post,
+      request: [{"application/json", {LangfuseSdk.Generated.GetMediaUploadUrlRequest, :t}}],
+      response: [
+        {200, {LangfuseSdk.Generated.GetMediaUploadUrlResponse, :t}},
+        {400, :map},
+        {401, :map},
+        {403, :map},
+        {404, :map},
+        {405, :map}
+      ],
+      opts: opts
+    })
+  end
+
+  @doc """
+  patch `/api/public/media/{mediaId}`
+
+  Patch a media record
+  """
+  @spec media_patch(String.t(), LangfuseSdk.Generated.PatchMediaBody.t(), keyword) ::
+          :ok | {:error, map}
+  def media_patch(mediaId, body, opts \\ []) do
+    client = opts[:client] || @default_client
+
+    client.request(%{
+      args: [mediaId: mediaId, body: body],
+      call: {LangfuseSdk.Generated.Media, :media_patch},
+      url: "/api/public/media/#{mediaId}",
+      body: body,
+      method: :patch,
+      request: [{"application/json", {LangfuseSdk.Generated.PatchMediaBody, :t}}],
+      response: [{204, :null}, {400, :map}, {401, :map}, {403, :map}, {404, :map}, {405, :map}],
+      opts: opts
+    })
+  end
+end

--- a/lib/langfuse_sdk/generated/operations/metrics.ex
+++ b/lib/langfuse_sdk/generated/operations/metrics.ex
@@ -17,6 +17,7 @@ defmodule LangfuseSdk.Generated.Metrics do
     * `traceName`: Optional filter by the name of the trace
     * `userId`: Optional filter by the userId associated with the trace
     * `tags`: Optional filter for metrics where traces include all of these tags
+    * `environment`: Optional filter for metrics where events include any of these environments
     * `fromTimestamp`: Optional filter to only include traces and observations on or after a certain datetime (ISO 8601)
     * `toTimestamp`: Optional filter to only include traces and observations before a certain datetime (ISO 8601)
 
@@ -26,7 +27,16 @@ defmodule LangfuseSdk.Generated.Metrics do
     client = opts[:client] || @default_client
 
     query =
-      Keyword.take(opts, [:fromTimestamp, :limit, :page, :tags, :toTimestamp, :traceName, :userId])
+      Keyword.take(opts, [
+        :environment,
+        :fromTimestamp,
+        :limit,
+        :page,
+        :tags,
+        :toTimestamp,
+        :traceName,
+        :userId
+      ])
 
     client.request(%{
       args: [],

--- a/lib/langfuse_sdk/generated/operations/observations.ex
+++ b/lib/langfuse_sdk/generated/operations/observations.ex
@@ -46,6 +46,7 @@ defmodule LangfuseSdk.Generated.Observations do
     * `type`
     * `traceId`
     * `parentObservationId`
+    * `environment`: Optional filter for observations where the environment is one of the provided values.
     * `fromStartTime`: Retrieve only observations with a start_time or or after this datetime (ISO 8601).
     * `toStartTime`: Retrieve only observations with a start_time before this datetime (ISO 8601).
     * `version`: Optional filter to only include observations with a certain version.
@@ -58,6 +59,7 @@ defmodule LangfuseSdk.Generated.Observations do
 
     query =
       Keyword.take(opts, [
+        :environment,
         :fromStartTime,
         :limit,
         :name,

--- a/lib/langfuse_sdk/generated/operations/prompt_version.ex
+++ b/lib/langfuse_sdk/generated/operations/prompt_version.ex
@@ -1,0 +1,28 @@
+defmodule LangfuseSdk.Generated.PromptVersion do
+  @moduledoc """
+  Provides API endpoint related to prompt version
+  """
+
+  @default_client LangfuseSdk.Support.Client
+
+  @doc """
+  patch `/api/public/v2/prompts/{name}/versions/{version}`
+
+  Update labels for a specific prompt version
+  """
+  @spec prompt_version_update(String.t(), integer, map, keyword) :: {:ok, map} | {:error, map}
+  def prompt_version_update(name, version, body, opts \\ []) do
+    client = opts[:client] || @default_client
+
+    client.request(%{
+      args: [name: name, version: version, body: body],
+      call: {LangfuseSdk.Generated.PromptVersion, :prompt_version_update},
+      url: "/api/public/v2/prompts/#{name}/versions/#{version}",
+      body: body,
+      method: :patch,
+      request: [{"application/json", :map}],
+      response: [{200, :map}, {400, :map}, {401, :map}, {403, :map}, {404, :map}, {405, :map}],
+      opts: opts
+    })
+  end
+end

--- a/lib/langfuse_sdk/generated/operations/score.ex
+++ b/lib/langfuse_sdk/generated/operations/score.ex
@@ -66,15 +66,18 @@ defmodule LangfuseSdk.Generated.Score do
     * `name`: Retrieve only scores with this name.
     * `fromTimestamp`: Optional filter to only include scores created on or after a certain datetime (ISO 8601)
     * `toTimestamp`: Optional filter to only include scores created before a certain datetime (ISO 8601)
+    * `environment`: Optional filter for scores where the environment is one of the provided values.
     * `source`: Retrieve only scores from a specific source.
     * `operator`: Retrieve only scores with <operator> value.
     * `value`: Retrieve only scores with <operator> value.
     * `scoreIds`: Comma-separated list of score IDs to limit the results to.
     * `configId`: Retrieve only scores with a specific configId.
+    * `queueId`: Retrieve only scores with a specific annotation queueId.
     * `dataType`: Retrieve only scores with a specific dataType.
+    * `traceTags`: Only scores linked to traces that include all of these tags will be returned.
 
   """
-  @spec score_get(keyword) :: {:ok, LangfuseSdk.Generated.Scores.t()} | {:error, map}
+  @spec score_get(keyword) :: {:ok, LangfuseSdk.Generated.GetScoresResponse.t()} | {:error, map}
   def score_get(opts \\ []) do
     client = opts[:client] || @default_client
 
@@ -82,14 +85,17 @@ defmodule LangfuseSdk.Generated.Score do
       Keyword.take(opts, [
         :configId,
         :dataType,
+        :environment,
         :fromTimestamp,
         :limit,
         :name,
         :operator,
         :page,
+        :queueId,
         :scoreIds,
         :source,
         :toTimestamp,
+        :traceTags,
         :userId,
         :value
       ])
@@ -101,7 +107,7 @@ defmodule LangfuseSdk.Generated.Score do
       method: :get,
       query: query,
       response: [
-        {200, {LangfuseSdk.Generated.Scores, :t}},
+        {200, {LangfuseSdk.Generated.GetScoresResponse, :t}},
         {400, :map},
         {401, :map},
         {403, :map},
@@ -111,6 +117,12 @@ defmodule LangfuseSdk.Generated.Score do
       opts: opts
     })
   end
+
+  @type score_get_by_id_200_json_resp :: %{
+          data_type: String.t(),
+          string_value: String.t() | nil,
+          value: number | nil
+        }
 
   @doc """
   get `/api/public/scores/{scoreId}`
@@ -126,8 +138,25 @@ defmodule LangfuseSdk.Generated.Score do
       call: {LangfuseSdk.Generated.Score, :score_get_by_id},
       url: "/api/public/scores/#{scoreId}",
       method: :get,
-      response: [{200, :map}, {400, :map}, {401, :map}, {403, :map}, {404, :map}, {405, :map}],
+      response: [
+        {200, {LangfuseSdk.Generated.Score, :score_get_by_id_200_json_resp}},
+        {400, :map},
+        {401, :map},
+        {403, :map},
+        {404, :map},
+        {405, :map}
+      ],
       opts: opts
     })
+  end
+
+  @doc false
+  @spec __fields__(atom) :: keyword
+  def __fields__(:score_get_by_id_200_json_resp) do
+    [
+      data_type: {:enum, ["BOOLEAN", "CATEGORICAL", "NUMERIC"]},
+      string_value: {:string, :generic},
+      value: :number
+    ]
   end
 end

--- a/lib/langfuse_sdk/generated/operations/sessions.ex
+++ b/lib/langfuse_sdk/generated/operations/sessions.ex
@@ -43,13 +43,14 @@ defmodule LangfuseSdk.Generated.Sessions do
     * `limit`: Limit of items per page. If you encounter api issues due to too large page sizes, try to reduce the limit.
     * `fromTimestamp`: Optional filter to only include sessions created on or after a certain datetime (ISO 8601)
     * `toTimestamp`: Optional filter to only include sessions created before a certain datetime (ISO 8601)
+    * `environment`: Optional filter for sessions where the environment is one of the provided values.
 
   """
   @spec sessions_list(keyword) ::
           {:ok, LangfuseSdk.Generated.PaginatedSessions.t()} | {:error, map}
   def sessions_list(opts \\ []) do
     client = opts[:client] || @default_client
-    query = Keyword.take(opts, [:fromTimestamp, :limit, :page, :toTimestamp])
+    query = Keyword.take(opts, [:environment, :fromTimestamp, :limit, :page, :toTimestamp])
 
     client.request(%{
       args: [],

--- a/lib/langfuse_sdk/generated/operations/trace.ex
+++ b/lib/langfuse_sdk/generated/operations/trace.ex
@@ -6,6 +6,62 @@ defmodule LangfuseSdk.Generated.Trace do
   @default_client LangfuseSdk.Support.Client
 
   @doc """
+  delete `/api/public/traces/{traceId}`
+
+  Delete a specific trace
+  """
+  @spec trace_delete(String.t(), keyword) ::
+          {:ok, LangfuseSdk.Generated.DeleteTraceResponse.t()} | {:error, map}
+  def trace_delete(traceId, opts \\ []) do
+    client = opts[:client] || @default_client
+
+    client.request(%{
+      args: [traceId: traceId],
+      call: {LangfuseSdk.Generated.Trace, :trace_delete},
+      url: "/api/public/traces/#{traceId}",
+      method: :delete,
+      response: [
+        {200, {LangfuseSdk.Generated.DeleteTraceResponse, :t}},
+        {400, :map},
+        {401, :map},
+        {403, :map},
+        {404, :map},
+        {405, :map}
+      ],
+      opts: opts
+    })
+  end
+
+  @doc """
+  delete `/api/public/traces`
+
+  Delete multiple traces
+  """
+  @spec trace_delete_multiple(map, keyword) ::
+          {:ok, LangfuseSdk.Generated.DeleteTraceResponse.t()} | {:error, map}
+  def trace_delete_multiple(body, opts \\ []) do
+    client = opts[:client] || @default_client
+
+    client.request(%{
+      args: [body: body],
+      call: {LangfuseSdk.Generated.Trace, :trace_delete_multiple},
+      url: "/api/public/traces",
+      body: body,
+      method: :delete,
+      request: [{"application/json", :map}],
+      response: [
+        {200, {LangfuseSdk.Generated.DeleteTraceResponse, :t}},
+        {400, :map},
+        {401, :map},
+        {403, :map},
+        {404, :map},
+        {405, :map}
+      ],
+      opts: opts
+    })
+  end
+
+  @doc """
   get `/api/public/traces/{traceId}`
 
   Get a specific trace
@@ -50,6 +106,7 @@ defmodule LangfuseSdk.Generated.Trace do
     * `tags`: Only traces that include all of these tags will be returned.
     * `version`: Optional filter to only include traces with a certain version.
     * `release`: Optional filter to only include traces with a certain release.
+    * `environment`: Optional filter for traces where the environment is one of the provided values.
 
   """
   @spec trace_list(keyword) :: {:ok, LangfuseSdk.Generated.Traces.t()} | {:error, map}
@@ -58,6 +115,7 @@ defmodule LangfuseSdk.Generated.Trace do
 
     query =
       Keyword.take(opts, [
+        :environment,
         :fromTimestamp,
         :limit,
         :name,

--- a/lib/langfuse_sdk/generated/schemas/annotation_queue.ex
+++ b/lib/langfuse_sdk/generated/schemas/annotation_queue.ex
@@ -1,0 +1,31 @@
+defmodule LangfuseSdk.Generated.AnnotationQueue do
+  @moduledoc """
+  Provides struct and type for a AnnotationQueue
+  """
+
+  @type t :: %__MODULE__{
+          created_at: DateTime.t(),
+          description: String.t() | nil,
+          id: String.t(),
+          name: String.t(),
+          score_config_ids: [String.t()],
+          updated_at: DateTime.t()
+        }
+
+  defstruct [:created_at, :description, :id, :name, :score_config_ids, :updated_at]
+
+  @doc false
+  @spec __fields__(atom) :: keyword
+  def __fields__(type \\ :t)
+
+  def __fields__(:t) do
+    [
+      created_at: {:string, :date_time},
+      description: {:string, :generic},
+      id: {:string, :generic},
+      name: {:string, :generic},
+      score_config_ids: [string: :generic],
+      updated_at: {:string, :date_time}
+    ]
+  end
+end

--- a/lib/langfuse_sdk/generated/schemas/annotation_queue_item.ex
+++ b/lib/langfuse_sdk/generated/schemas/annotation_queue_item.ex
@@ -1,0 +1,44 @@
+defmodule LangfuseSdk.Generated.AnnotationQueueItem do
+  @moduledoc """
+  Provides struct and type for a AnnotationQueueItem
+  """
+
+  @type t :: %__MODULE__{
+          completed_at: DateTime.t() | nil,
+          created_at: DateTime.t(),
+          id: String.t(),
+          object_id: String.t(),
+          object_type: String.t(),
+          queue_id: String.t(),
+          status: String.t(),
+          updated_at: DateTime.t()
+        }
+
+  defstruct [
+    :completed_at,
+    :created_at,
+    :id,
+    :object_id,
+    :object_type,
+    :queue_id,
+    :status,
+    :updated_at
+  ]
+
+  @doc false
+  @spec __fields__(atom) :: keyword
+  def __fields__(type \\ :t)
+
+  def __fields__(:t) do
+    [
+      completed_at: {:string, :date_time},
+      created_at: {:string, :date_time},
+      id: {:string, :generic},
+      object_id: {:string, :generic},
+      object_type: {:enum, ["TRACE", "OBSERVATION"]},
+      queue_id: {:string, :generic},
+      status: {:enum, ["PENDING", "COMPLETED"]},
+      updated_at: {:string, :date_time}
+    ]
+  end
+end

--- a/lib/langfuse_sdk/generated/schemas/comment.ex
+++ b/lib/langfuse_sdk/generated/schemas/comment.ex
@@ -1,0 +1,44 @@
+defmodule LangfuseSdk.Generated.Comment do
+  @moduledoc """
+  Provides struct and type for a Comment
+  """
+
+  @type t :: %__MODULE__{
+          author_user_id: String.t() | nil,
+          content: String.t(),
+          created_at: DateTime.t(),
+          id: String.t(),
+          object_id: String.t(),
+          object_type: String.t(),
+          project_id: String.t(),
+          updated_at: DateTime.t()
+        }
+
+  defstruct [
+    :author_user_id,
+    :content,
+    :created_at,
+    :id,
+    :object_id,
+    :object_type,
+    :project_id,
+    :updated_at
+  ]
+
+  @doc false
+  @spec __fields__(atom) :: keyword
+  def __fields__(type \\ :t)
+
+  def __fields__(:t) do
+    [
+      author_user_id: {:string, :generic},
+      content: {:string, :generic},
+      created_at: {:string, :date_time},
+      id: {:string, :generic},
+      object_id: {:string, :generic},
+      object_type: {:enum, ["TRACE", "OBSERVATION", "SESSION", "PROMPT"]},
+      project_id: {:string, :generic},
+      updated_at: {:string, :date_time}
+    ]
+  end
+end

--- a/lib/langfuse_sdk/generated/schemas/create_annotation_queue_item_request.ex
+++ b/lib/langfuse_sdk/generated/schemas/create_annotation_queue_item_request.ex
@@ -1,0 +1,21 @@
+defmodule LangfuseSdk.Generated.CreateAnnotationQueueItemRequest do
+  @moduledoc """
+  Provides struct and type for a CreateAnnotationQueueItemRequest
+  """
+
+  @type t :: %__MODULE__{object_id: String.t(), object_type: String.t(), status: String.t() | nil}
+
+  defstruct [:object_id, :object_type, :status]
+
+  @doc false
+  @spec __fields__(atom) :: keyword
+  def __fields__(type \\ :t)
+
+  def __fields__(:t) do
+    [
+      object_id: {:string, :generic},
+      object_type: {:enum, ["TRACE", "OBSERVATION"]},
+      status: {:enum, ["PENDING", "COMPLETED"]}
+    ]
+  end
+end

--- a/lib/langfuse_sdk/generated/schemas/create_comment_request.ex
+++ b/lib/langfuse_sdk/generated/schemas/create_comment_request.ex
@@ -1,0 +1,29 @@
+defmodule LangfuseSdk.Generated.CreateCommentRequest do
+  @moduledoc """
+  Provides struct and type for a CreateCommentRequest
+  """
+
+  @type t :: %__MODULE__{
+          author_user_id: String.t() | nil,
+          content: String.t(),
+          object_id: String.t(),
+          object_type: String.t(),
+          project_id: String.t()
+        }
+
+  defstruct [:author_user_id, :content, :object_id, :object_type, :project_id]
+
+  @doc false
+  @spec __fields__(atom) :: keyword
+  def __fields__(type \\ :t)
+
+  def __fields__(:t) do
+    [
+      author_user_id: {:string, :generic},
+      content: {:string, :generic},
+      object_id: {:string, :generic},
+      object_type: {:string, :generic},
+      project_id: {:string, :generic}
+    ]
+  end
+end

--- a/lib/langfuse_sdk/generated/schemas/create_comment_response.ex
+++ b/lib/langfuse_sdk/generated/schemas/create_comment_response.ex
@@ -1,0 +1,17 @@
+defmodule LangfuseSdk.Generated.CreateCommentResponse do
+  @moduledoc """
+  Provides struct and type for a CreateCommentResponse
+  """
+
+  @type t :: %__MODULE__{id: String.t()}
+
+  defstruct [:id]
+
+  @doc false
+  @spec __fields__(atom) :: keyword
+  def __fields__(type \\ :t)
+
+  def __fields__(:t) do
+    [id: {:string, :generic}]
+  end
+end

--- a/lib/langfuse_sdk/generated/schemas/create_event_body.ex
+++ b/lib/langfuse_sdk/generated/schemas/create_event_body.ex
@@ -4,6 +4,7 @@ defmodule LangfuseSdk.Generated.CreateEventBody do
   """
 
   @type t :: %__MODULE__{
+          environment: String.t() | nil,
           input: map | nil,
           level: String.t() | nil,
           metadata: map | nil,
@@ -17,6 +18,7 @@ defmodule LangfuseSdk.Generated.CreateEventBody do
         }
 
   defstruct [
+    :environment,
     :input,
     :level,
     :metadata,
@@ -35,6 +37,7 @@ defmodule LangfuseSdk.Generated.CreateEventBody do
 
   def __fields__(:t) do
     [
+      environment: {:string, :generic},
       input: :map,
       level: {:enum, ["DEBUG", "DEFAULT", "WARNING", "ERROR"]},
       metadata: :map,

--- a/lib/langfuse_sdk/generated/schemas/create_model_request.ex
+++ b/lib/langfuse_sdk/generated/schemas/create_model_request.ex
@@ -12,7 +12,7 @@ defmodule LangfuseSdk.Generated.CreateModelRequest do
           tokenizer_config: map | nil,
           tokenizer_id: String.t() | nil,
           total_price: number | nil,
-          unit: String.t()
+          unit: String.t() | nil
         }
 
   defstruct [

--- a/lib/langfuse_sdk/generated/schemas/create_score_request.ex
+++ b/lib/langfuse_sdk/generated/schemas/create_score_request.ex
@@ -7,6 +7,7 @@ defmodule LangfuseSdk.Generated.CreateScoreRequest do
           comment: String.t() | nil,
           config_id: String.t() | nil,
           data_type: String.t() | nil,
+          environment: String.t() | nil,
           id: String.t() | nil,
           name: String.t(),
           observation_id: String.t() | nil,
@@ -14,7 +15,17 @@ defmodule LangfuseSdk.Generated.CreateScoreRequest do
           value: number | String.t()
         }
 
-  defstruct [:comment, :config_id, :data_type, :id, :name, :observation_id, :trace_id, :value]
+  defstruct [
+    :comment,
+    :config_id,
+    :data_type,
+    :environment,
+    :id,
+    :name,
+    :observation_id,
+    :trace_id,
+    :value
+  ]
 
   @doc false
   @spec __fields__(atom) :: keyword
@@ -25,6 +36,7 @@ defmodule LangfuseSdk.Generated.CreateScoreRequest do
       comment: {:string, :generic},
       config_id: {:string, :generic},
       data_type: {:enum, ["NUMERIC", "BOOLEAN", "CATEGORICAL"]},
+      environment: {:string, :generic},
       id: {:string, :generic},
       name: {:string, :generic},
       observation_id: {:string, :generic},

--- a/lib/langfuse_sdk/generated/schemas/delete_annotation_queue_item_response.ex
+++ b/lib/langfuse_sdk/generated/schemas/delete_annotation_queue_item_response.ex
@@ -1,0 +1,17 @@
+defmodule LangfuseSdk.Generated.DeleteAnnotationQueueItemResponse do
+  @moduledoc """
+  Provides struct and type for a DeleteAnnotationQueueItemResponse
+  """
+
+  @type t :: %__MODULE__{message: String.t(), success: boolean}
+
+  defstruct [:message, :success]
+
+  @doc false
+  @spec __fields__(atom) :: keyword
+  def __fields__(type \\ :t)
+
+  def __fields__(:t) do
+    [message: {:string, :generic}, success: :boolean]
+  end
+end

--- a/lib/langfuse_sdk/generated/schemas/delete_dataset_item_response.ex
+++ b/lib/langfuse_sdk/generated/schemas/delete_dataset_item_response.ex
@@ -1,0 +1,17 @@
+defmodule LangfuseSdk.Generated.DeleteDatasetItemResponse do
+  @moduledoc """
+  Provides struct and type for a DeleteDatasetItemResponse
+  """
+
+  @type t :: %__MODULE__{message: String.t()}
+
+  defstruct [:message]
+
+  @doc false
+  @spec __fields__(atom) :: keyword
+  def __fields__(type \\ :t)
+
+  def __fields__(:t) do
+    [message: {:string, :generic}]
+  end
+end

--- a/lib/langfuse_sdk/generated/schemas/delete_dataset_run_response.ex
+++ b/lib/langfuse_sdk/generated/schemas/delete_dataset_run_response.ex
@@ -1,0 +1,17 @@
+defmodule LangfuseSdk.Generated.DeleteDatasetRunResponse do
+  @moduledoc """
+  Provides struct and type for a DeleteDatasetRunResponse
+  """
+
+  @type t :: %__MODULE__{message: String.t()}
+
+  defstruct [:message]
+
+  @doc false
+  @spec __fields__(atom) :: keyword
+  def __fields__(type \\ :t)
+
+  def __fields__(:t) do
+    [message: {:string, :generic}]
+  end
+end

--- a/lib/langfuse_sdk/generated/schemas/delete_trace_response.ex
+++ b/lib/langfuse_sdk/generated/schemas/delete_trace_response.ex
@@ -1,0 +1,17 @@
+defmodule LangfuseSdk.Generated.DeleteTraceResponse do
+  @moduledoc """
+  Provides struct and type for a DeleteTraceResponse
+  """
+
+  @type t :: %__MODULE__{message: String.t()}
+
+  defstruct [:message]
+
+  @doc false
+  @spec __fields__(atom) :: keyword
+  def __fields__(type \\ :t)
+
+  def __fields__(:t) do
+    [message: {:string, :generic}]
+  end
+end

--- a/lib/langfuse_sdk/generated/schemas/get_comments_response.ex
+++ b/lib/langfuse_sdk/generated/schemas/get_comments_response.ex
@@ -1,0 +1,23 @@
+defmodule LangfuseSdk.Generated.GetCommentsResponse do
+  @moduledoc """
+  Provides struct and type for a GetCommentsResponse
+  """
+
+  @type t :: %__MODULE__{
+          data: [LangfuseSdk.Generated.Comment.t()],
+          meta: LangfuseSdk.Generated.UtilsMetaResponse.t()
+        }
+
+  defstruct [:data, :meta]
+
+  @doc false
+  @spec __fields__(atom) :: keyword
+  def __fields__(type \\ :t)
+
+  def __fields__(:t) do
+    [
+      data: [{LangfuseSdk.Generated.Comment, :t}],
+      meta: {LangfuseSdk.Generated.UtilsMetaResponse, :t}
+    ]
+  end
+end

--- a/lib/langfuse_sdk/generated/schemas/get_media_response.ex
+++ b/lib/langfuse_sdk/generated/schemas/get_media_response.ex
@@ -1,0 +1,31 @@
+defmodule LangfuseSdk.Generated.GetMediaResponse do
+  @moduledoc """
+  Provides struct and type for a GetMediaResponse
+  """
+
+  @type t :: %__MODULE__{
+          content_length: integer,
+          content_type: String.t(),
+          media_id: String.t(),
+          uploaded_at: DateTime.t(),
+          url: String.t(),
+          url_expiry: String.t()
+        }
+
+  defstruct [:content_length, :content_type, :media_id, :uploaded_at, :url, :url_expiry]
+
+  @doc false
+  @spec __fields__(atom) :: keyword
+  def __fields__(type \\ :t)
+
+  def __fields__(:t) do
+    [
+      content_length: :integer,
+      content_type: {:string, :generic},
+      media_id: {:string, :generic},
+      uploaded_at: {:string, :date_time},
+      url: {:string, :generic},
+      url_expiry: {:string, :generic}
+    ]
+  end
+end

--- a/lib/langfuse_sdk/generated/schemas/get_media_upload_url_request.ex
+++ b/lib/langfuse_sdk/generated/schemas/get_media_upload_url_request.ex
@@ -1,0 +1,63 @@
+defmodule LangfuseSdk.Generated.GetMediaUploadUrlRequest do
+  @moduledoc """
+  Provides struct and type for a GetMediaUploadUrlRequest
+  """
+
+  @type t :: %__MODULE__{
+          content_length: integer,
+          content_type: String.t(),
+          field: String.t(),
+          observation_id: String.t() | nil,
+          sha2_56_hash: String.t(),
+          trace_id: String.t()
+        }
+
+  defstruct [:content_length, :content_type, :field, :observation_id, :sha2_56_hash, :trace_id]
+
+  @doc false
+  @spec __fields__(atom) :: keyword
+  def __fields__(type \\ :t)
+
+  def __fields__(:t) do
+    [
+      content_length: :integer,
+      content_type:
+        {:enum,
+         [
+           "image/png",
+           "image/jpeg",
+           "image/jpg",
+           "image/webp",
+           "image/gif",
+           "image/svg+xml",
+           "image/tiff",
+           "image/bmp",
+           "audio/mpeg",
+           "audio/mp3",
+           "audio/wav",
+           "audio/ogg",
+           "audio/oga",
+           "audio/aac",
+           "audio/mp4",
+           "audio/flac",
+           "video/mp4",
+           "video/webm",
+           "text/plain",
+           "text/html",
+           "text/css",
+           "text/csv",
+           "application/pdf",
+           "application/msword",
+           "application/vnd.ms-excel",
+           "application/zip",
+           "application/json",
+           "application/xml",
+           "application/octet-stream"
+         ]},
+      field: {:string, :generic},
+      observation_id: {:string, :generic},
+      sha2_56_hash: {:string, :generic},
+      trace_id: {:string, :generic}
+    ]
+  end
+end

--- a/lib/langfuse_sdk/generated/schemas/get_media_upload_url_response.ex
+++ b/lib/langfuse_sdk/generated/schemas/get_media_upload_url_response.ex
@@ -1,0 +1,17 @@
+defmodule LangfuseSdk.Generated.GetMediaUploadUrlResponse do
+  @moduledoc """
+  Provides struct and type for a GetMediaUploadUrlResponse
+  """
+
+  @type t :: %__MODULE__{media_id: String.t(), upload_url: String.t() | nil}
+
+  defstruct [:media_id, :upload_url]
+
+  @doc false
+  @spec __fields__(atom) :: keyword
+  def __fields__(type \\ :t)
+
+  def __fields__(:t) do
+    [media_id: {:string, :generic}, upload_url: {:string, :generic}]
+  end
+end

--- a/lib/langfuse_sdk/generated/schemas/get_scores_response.ex
+++ b/lib/langfuse_sdk/generated/schemas/get_scores_response.ex
@@ -1,0 +1,23 @@
+defmodule LangfuseSdk.Generated.GetScoresResponse do
+  @moduledoc """
+  Provides struct and type for a GetScoresResponse
+  """
+
+  @type t :: %__MODULE__{
+          data: [LangfuseSdk.Generated.GetScoresResponseData.t()],
+          meta: LangfuseSdk.Generated.UtilsMetaResponse.t()
+        }
+
+  defstruct [:data, :meta]
+
+  @doc false
+  @spec __fields__(atom) :: keyword
+  def __fields__(type \\ :t)
+
+  def __fields__(:t) do
+    [
+      data: [{LangfuseSdk.Generated.GetScoresResponseData, :t}],
+      meta: {LangfuseSdk.Generated.UtilsMetaResponse, :t}
+    ]
+  end
+end

--- a/lib/langfuse_sdk/generated/schemas/get_scores_response_data.ex
+++ b/lib/langfuse_sdk/generated/schemas/get_scores_response_data.ex
@@ -1,0 +1,23 @@
+defmodule LangfuseSdk.Generated.GetScoresResponseData do
+  @moduledoc """
+  Provides struct and types for a GetScoresResponseData
+  """
+
+  @type t :: %__MODULE__{
+          data_type: String.t(),
+          trace: LangfuseSdk.Generated.GetScoresResponseTraceData.t() | nil
+        }
+
+  defstruct [:data_type, :trace]
+
+  @doc false
+  @spec __fields__(atom) :: keyword
+  def __fields__(type \\ :t)
+
+  def __fields__(:t) do
+    [
+      data_type: {:enum, ["BOOLEAN", "CATEGORICAL", "NUMERIC"]},
+      trace: {LangfuseSdk.Generated.GetScoresResponseTraceData, :t}
+    ]
+  end
+end

--- a/lib/langfuse_sdk/generated/schemas/get_scores_response_trace_data.ex
+++ b/lib/langfuse_sdk/generated/schemas/get_scores_response_trace_data.ex
@@ -1,0 +1,21 @@
+defmodule LangfuseSdk.Generated.GetScoresResponseTraceData do
+  @moduledoc """
+  Provides struct and type for a GetScoresResponseTraceData
+  """
+
+  @type t :: %__MODULE__{
+          environment: String.t() | nil,
+          tags: [String.t()] | nil,
+          user_id: String.t() | nil
+        }
+
+  defstruct [:environment, :tags, :user_id]
+
+  @doc false
+  @spec __fields__(atom) :: keyword
+  def __fields__(type \\ :t)
+
+  def __fields__(:t) do
+    [environment: {:string, :generic}, tags: [string: :generic], user_id: {:string, :generic}]
+  end
+end

--- a/lib/langfuse_sdk/generated/schemas/model.ex
+++ b/lib/langfuse_sdk/generated/schemas/model.ex
@@ -10,11 +10,11 @@ defmodule LangfuseSdk.Generated.Model do
           match_pattern: String.t(),
           model_name: String.t(),
           output_price: number | nil,
-          start_date: Date.t() | nil,
+          start_date: DateTime.t() | nil,
           tokenizer_config: map | nil,
           tokenizer_id: String.t() | nil,
           total_price: number | nil,
-          unit: String.t()
+          unit: String.t() | nil
         }
 
   defstruct [
@@ -43,7 +43,7 @@ defmodule LangfuseSdk.Generated.Model do
       match_pattern: {:string, :generic},
       model_name: {:string, :generic},
       output_price: :number,
-      start_date: {:string, :date},
+      start_date: {:string, :date_time},
       tokenizer_config: :map,
       tokenizer_id: {:string, :generic},
       total_price: :number,

--- a/lib/langfuse_sdk/generated/schemas/observation_body.ex
+++ b/lib/langfuse_sdk/generated/schemas/observation_body.ex
@@ -6,6 +6,7 @@ defmodule LangfuseSdk.Generated.ObservationBody do
   @type t :: %__MODULE__{
           completion_start_time: DateTime.t() | nil,
           end_time: DateTime.t() | nil,
+          environment: String.t() | nil,
           id: String.t() | nil,
           input: map | nil,
           level: String.t() | nil,
@@ -26,6 +27,7 @@ defmodule LangfuseSdk.Generated.ObservationBody do
   defstruct [
     :completion_start_time,
     :end_time,
+    :environment,
     :id,
     :input,
     :level,
@@ -51,6 +53,7 @@ defmodule LangfuseSdk.Generated.ObservationBody do
     [
       completion_start_time: {:string, :date_time},
       end_time: {:string, :date_time},
+      environment: {:string, :generic},
       id: {:string, :generic},
       input: :map,
       level: {:enum, ["DEBUG", "DEFAULT", "WARNING", "ERROR"]},

--- a/lib/langfuse_sdk/generated/schemas/observations_view.ex
+++ b/lib/langfuse_sdk/generated/schemas/observations_view.ex
@@ -5,7 +5,9 @@ defmodule LangfuseSdk.Generated.ObservationsView do
 
   @type t :: %__MODULE__{
           completion_start_time: DateTime.t() | nil,
+          cost_details: LangfuseSdk.Generated.ObservationsViewCostDetails.t() | nil,
           end_time: DateTime.t() | nil,
+          environment: String.t() | nil,
           id: String.t() | nil,
           input: map | nil,
           level: String.t() | nil,
@@ -21,12 +23,15 @@ defmodule LangfuseSdk.Generated.ObservationsView do
           trace_id: String.t() | nil,
           type: String.t() | nil,
           usage: LangfuseSdk.Generated.Usage.t() | nil,
+          usage_details: LangfuseSdk.Generated.ObservationsViewUsageDetails.t() | nil,
           version: String.t() | nil
         }
 
   defstruct [
     :completion_start_time,
+    :cost_details,
     :end_time,
+    :environment,
     :id,
     :input,
     :level,
@@ -42,6 +47,7 @@ defmodule LangfuseSdk.Generated.ObservationsView do
     :trace_id,
     :type,
     :usage,
+    :usage_details,
     :version
   ]
 
@@ -52,7 +58,9 @@ defmodule LangfuseSdk.Generated.ObservationsView do
   def __fields__(:t) do
     [
       completion_start_time: {:string, :date_time},
+      cost_details: {LangfuseSdk.Generated.ObservationsViewCostDetails, :t},
       end_time: {:string, :date_time},
+      environment: {:string, :generic},
       id: {:string, :generic},
       input: :map,
       level: {:enum, ["DEBUG", "DEFAULT", "WARNING", "ERROR"]},
@@ -68,6 +76,7 @@ defmodule LangfuseSdk.Generated.ObservationsView do
       trace_id: {:string, :generic},
       type: {:string, :generic},
       usage: {LangfuseSdk.Generated.Usage, :t},
+      usage_details: {LangfuseSdk.Generated.ObservationsViewUsageDetails, :t},
       version: {:string, :generic}
     ]
   end

--- a/lib/langfuse_sdk/generated/schemas/observations_view_cost_details.ex
+++ b/lib/langfuse_sdk/generated/schemas/observations_view_cost_details.ex
@@ -1,0 +1,17 @@
+defmodule LangfuseSdk.Generated.ObservationsViewCostDetails do
+  @moduledoc """
+  Provides struct and type for a ObservationsViewCostDetails
+  """
+
+  @type t :: %__MODULE__{}
+
+  defstruct []
+
+  @doc false
+  @spec __fields__(atom) :: keyword
+  def __fields__(type \\ :t)
+
+  def __fields__(:t) do
+    []
+  end
+end

--- a/lib/langfuse_sdk/generated/schemas/observations_view_usage_details.ex
+++ b/lib/langfuse_sdk/generated/schemas/observations_view_usage_details.ex
@@ -1,0 +1,17 @@
+defmodule LangfuseSdk.Generated.ObservationsViewUsageDetails do
+  @moduledoc """
+  Provides struct and type for a ObservationsViewUsageDetails
+  """
+
+  @type t :: %__MODULE__{}
+
+  defstruct []
+
+  @doc false
+  @spec __fields__(atom) :: keyword
+  def __fields__(type \\ :t)
+
+  def __fields__(:t) do
+    []
+  end
+end

--- a/lib/langfuse_sdk/generated/schemas/paginated_annotation_queue_items.ex
+++ b/lib/langfuse_sdk/generated/schemas/paginated_annotation_queue_items.ex
@@ -1,0 +1,23 @@
+defmodule LangfuseSdk.Generated.PaginatedAnnotationQueueItems do
+  @moduledoc """
+  Provides struct and type for a PaginatedAnnotationQueueItems
+  """
+
+  @type t :: %__MODULE__{
+          data: [LangfuseSdk.Generated.AnnotationQueueItem.t()],
+          meta: LangfuseSdk.Generated.UtilsMetaResponse.t()
+        }
+
+  defstruct [:data, :meta]
+
+  @doc false
+  @spec __fields__(atom) :: keyword
+  def __fields__(type \\ :t)
+
+  def __fields__(:t) do
+    [
+      data: [{LangfuseSdk.Generated.AnnotationQueueItem, :t}],
+      meta: {LangfuseSdk.Generated.UtilsMetaResponse, :t}
+    ]
+  end
+end

--- a/lib/langfuse_sdk/generated/schemas/paginated_annotation_queues.ex
+++ b/lib/langfuse_sdk/generated/schemas/paginated_annotation_queues.ex
@@ -1,0 +1,23 @@
+defmodule LangfuseSdk.Generated.PaginatedAnnotationQueues do
+  @moduledoc """
+  Provides struct and type for a PaginatedAnnotationQueues
+  """
+
+  @type t :: %__MODULE__{
+          data: [LangfuseSdk.Generated.AnnotationQueue.t()],
+          meta: LangfuseSdk.Generated.UtilsMetaResponse.t()
+        }
+
+  defstruct [:data, :meta]
+
+  @doc false
+  @spec __fields__(atom) :: keyword
+  def __fields__(type \\ :t)
+
+  def __fields__(:t) do
+    [
+      data: [{LangfuseSdk.Generated.AnnotationQueue, :t}],
+      meta: {LangfuseSdk.Generated.UtilsMetaResponse, :t}
+    ]
+  end
+end

--- a/lib/langfuse_sdk/generated/schemas/patch_media_body.ex
+++ b/lib/langfuse_sdk/generated/schemas/patch_media_body.ex
@@ -1,0 +1,27 @@
+defmodule LangfuseSdk.Generated.PatchMediaBody do
+  @moduledoc """
+  Provides struct and type for a PatchMediaBody
+  """
+
+  @type t :: %__MODULE__{
+          upload_http_error: String.t() | nil,
+          upload_http_status: integer,
+          upload_time_ms: integer | nil,
+          uploaded_at: DateTime.t()
+        }
+
+  defstruct [:upload_http_error, :upload_http_status, :upload_time_ms, :uploaded_at]
+
+  @doc false
+  @spec __fields__(atom) :: keyword
+  def __fields__(type \\ :t)
+
+  def __fields__(:t) do
+    [
+      upload_http_error: {:string, :generic},
+      upload_http_status: :integer,
+      upload_time_ms: :integer,
+      uploaded_at: {:string, :date_time}
+    ]
+  end
+end

--- a/lib/langfuse_sdk/generated/schemas/score_body.ex
+++ b/lib/langfuse_sdk/generated/schemas/score_body.ex
@@ -7,6 +7,7 @@ defmodule LangfuseSdk.Generated.ScoreBody do
           comment: String.t() | nil,
           config_id: String.t() | nil,
           data_type: String.t() | nil,
+          environment: String.t() | nil,
           id: String.t() | nil,
           name: String.t(),
           observation_id: String.t() | nil,
@@ -14,7 +15,17 @@ defmodule LangfuseSdk.Generated.ScoreBody do
           value: number | String.t()
         }
 
-  defstruct [:comment, :config_id, :data_type, :id, :name, :observation_id, :trace_id, :value]
+  defstruct [
+    :comment,
+    :config_id,
+    :data_type,
+    :environment,
+    :id,
+    :name,
+    :observation_id,
+    :trace_id,
+    :value
+  ]
 
   @doc false
   @spec __fields__(atom) :: keyword
@@ -25,6 +36,7 @@ defmodule LangfuseSdk.Generated.ScoreBody do
       comment: {:string, :generic},
       config_id: {:string, :generic},
       data_type: {:enum, ["NUMERIC", "BOOLEAN", "CATEGORICAL"]},
+      environment: {:string, :generic},
       id: {:string, :generic},
       name: {:string, :generic},
       observation_id: {:string, :generic},

--- a/lib/langfuse_sdk/generated/schemas/session.ex
+++ b/lib/langfuse_sdk/generated/schemas/session.ex
@@ -3,15 +3,25 @@ defmodule LangfuseSdk.Generated.Session do
   Provides struct and type for a Session
   """
 
-  @type t :: %__MODULE__{created_at: DateTime.t(), id: String.t(), project_id: String.t()}
+  @type t :: %__MODULE__{
+          created_at: DateTime.t(),
+          environment: String.t() | nil,
+          id: String.t(),
+          project_id: String.t()
+        }
 
-  defstruct [:created_at, :id, :project_id]
+  defstruct [:created_at, :environment, :id, :project_id]
 
   @doc false
   @spec __fields__(atom) :: keyword
   def __fields__(type \\ :t)
 
   def __fields__(:t) do
-    [created_at: {:string, :date_time}, id: {:string, :generic}, project_id: {:string, :generic}]
+    [
+      created_at: {:string, :date_time},
+      environment: {:string, :generic},
+      id: {:string, :generic},
+      project_id: {:string, :generic}
+    ]
   end
 end

--- a/lib/langfuse_sdk/generated/schemas/session_with_traces.ex
+++ b/lib/langfuse_sdk/generated/schemas/session_with_traces.ex
@@ -5,17 +5,23 @@ defmodule LangfuseSdk.Generated.SessionWithTraces do
 
   @type t :: %__MODULE__{
           created_at: DateTime.t() | nil,
+          environment: String.t() | nil,
           id: String.t() | nil,
           project_id: String.t() | nil
         }
 
-  defstruct [:created_at, :id, :project_id]
+  defstruct [:created_at, :environment, :id, :project_id]
 
   @doc false
   @spec __fields__(atom) :: keyword
   def __fields__(type \\ :t)
 
   def __fields__(:t) do
-    [created_at: {:string, :date_time}, id: {:string, :generic}, project_id: {:string, :generic}]
+    [
+      created_at: {:string, :date_time},
+      environment: {:string, :generic},
+      id: {:string, :generic},
+      project_id: {:string, :generic}
+    ]
   end
 end

--- a/lib/langfuse_sdk/generated/schemas/trace_body.ex
+++ b/lib/langfuse_sdk/generated/schemas/trace_body.ex
@@ -4,6 +4,7 @@ defmodule LangfuseSdk.Generated.TraceBody do
   """
 
   @type t :: %__MODULE__{
+          environment: String.t() | nil,
           id: String.t() | nil,
           input: map | nil,
           metadata: map | nil,
@@ -19,6 +20,7 @@ defmodule LangfuseSdk.Generated.TraceBody do
         }
 
   defstruct [
+    :environment,
     :id,
     :input,
     :metadata,
@@ -39,6 +41,7 @@ defmodule LangfuseSdk.Generated.TraceBody do
 
   def __fields__(:t) do
     [
+      environment: {:string, :generic},
       id: {:string, :generic},
       input: :map,
       metadata: :map,

--- a/lib/langfuse_sdk/generated/schemas/trace_with_details.ex
+++ b/lib/langfuse_sdk/generated/schemas/trace_with_details.ex
@@ -4,6 +4,7 @@ defmodule LangfuseSdk.Generated.TraceWithDetails do
   """
 
   @type t :: %__MODULE__{
+          environment: String.t() | nil,
           id: String.t() | nil,
           input: map | nil,
           metadata: map | nil,
@@ -19,6 +20,7 @@ defmodule LangfuseSdk.Generated.TraceWithDetails do
         }
 
   defstruct [
+    :environment,
     :id,
     :input,
     :metadata,
@@ -39,6 +41,7 @@ defmodule LangfuseSdk.Generated.TraceWithDetails do
 
   def __fields__(:t) do
     [
+      environment: {:string, :generic},
       id: {:string, :generic},
       input: :map,
       metadata: :map,

--- a/lib/langfuse_sdk/generated/schemas/trace_with_full_details.ex
+++ b/lib/langfuse_sdk/generated/schemas/trace_with_full_details.ex
@@ -4,6 +4,7 @@ defmodule LangfuseSdk.Generated.TraceWithFullDetails do
   """
 
   @type t :: %__MODULE__{
+          environment: String.t() | nil,
           id: String.t() | nil,
           input: map | nil,
           metadata: map | nil,
@@ -19,6 +20,7 @@ defmodule LangfuseSdk.Generated.TraceWithFullDetails do
         }
 
   defstruct [
+    :environment,
     :id,
     :input,
     :metadata,
@@ -39,6 +41,7 @@ defmodule LangfuseSdk.Generated.TraceWithFullDetails do
 
   def __fields__(:t) do
     [
+      environment: {:string, :generic},
       id: {:string, :generic},
       input: :map,
       metadata: :map,

--- a/lib/langfuse_sdk/generated/schemas/update_annotation_queue_item_request.ex
+++ b/lib/langfuse_sdk/generated/schemas/update_annotation_queue_item_request.ex
@@ -1,0 +1,17 @@
+defmodule LangfuseSdk.Generated.UpdateAnnotationQueueItemRequest do
+  @moduledoc """
+  Provides struct and type for a UpdateAnnotationQueueItemRequest
+  """
+
+  @type t :: %__MODULE__{status: String.t() | nil}
+
+  defstruct [:status]
+
+  @doc false
+  @spec __fields__(atom) :: keyword
+  def __fields__(type \\ :t)
+
+  def __fields__(:t) do
+    [status: {:enum, ["PENDING", "COMPLETED"]}]
+  end
+end

--- a/lib/langfuse_sdk/support/client.ex
+++ b/lib/langfuse_sdk/support/client.ex
@@ -53,6 +53,17 @@ defmodule LangfuseSdk.Support.Client do
     |> Req.post()
   end
 
+  defp execute_request(%{method: :patch} = opts) do
+    [
+      url: build_endpoint(opts.url),
+      body: encode_body(opts[:body]),
+      retry: :transient
+    ]
+    |> Req.new()
+    |> Auth.put_auth_headers()
+    |> Req.patch()
+  end
+
   # Helper function to build the URL
   defp build_endpoint(path) do
     host = Application.fetch_env!(:langfuse_sdk, :host)

--- a/lib/langfuse_sdk/support/media.ex
+++ b/lib/langfuse_sdk/support/media.ex
@@ -1,0 +1,128 @@
+defmodule LangfuseSdk.Support.Media do
+  require Logger
+
+  def replace_image_urls(generation) do
+    generation_map = Map.from_struct(generation)
+
+    generation_map
+    |> maybe_process(:input)
+    |> maybe_process(:output)
+    |> LangfuseSdk.Tracing.Generation.new()
+  end
+
+  defp maybe_process(generation_map, key) do
+    case generation_map[key] do
+      content when is_list(content) ->
+        update_in(generation_map, [key], &process_content_list(&1, generation_map, key))
+
+      _ ->
+        generation_map
+    end
+  end
+
+  defp process_content_list(content_list, generation_map, key) do
+    Enum.map(content_list, &process_content_item(&1, generation_map, key))
+  end
+
+  defp process_content_item(content_item, generation_map, key) do
+    update_in(content_item, ["content"], &process_content_entries(&1, generation_map, key))
+  end
+
+  defp process_content_entries(content_entries, generation_map, key) do
+    Enum.map(content_entries, &process_entry(&1, generation_map, key))
+  end
+
+  defp process_entry(
+         %{"type" => "image_url", "image_url" => %{"url" => url}} = entry,
+         generation_map,
+         key
+       ) do
+    decode_info = decode_info(url)
+
+    media_token =
+      get_media_token(
+        generation_map.trace_id,
+        generation_map.id,
+        Atom.to_string(key),
+        decode_info
+      )
+
+    put_in(entry, ["image_url", "url"], media_token)
+  end
+
+  defp process_entry(entry, _generation_map, _key), do: entry
+
+  defp decode_info(data_uri) do
+    [metadata_str, base64_str] = String.split(data_uri, ",", parts: 2)
+
+    content_type =
+      metadata_str
+      |> String.replace_prefix("data:", "")
+      |> String.replace_suffix(";base64", "")
+
+    clean_base64 =
+      base64_str
+      |> String.trim()
+      |> String.replace(~r/\s/, "")
+
+    image_bytes = Base.decode64!(clean_base64)
+    content_length = byte_size(image_bytes)
+
+    sha256_digest = :crypto.hash(:sha256, image_bytes)
+    sha256_b64 = Base.encode64(sha256_digest)
+
+    %{
+      content_type: content_type,
+      content_length: content_length,
+      sha2_56_hash: sha256_b64,
+      image_bytes: image_bytes
+    }
+  end
+
+  defp get_media_token(trace_id, observation_id, field, metadata) do
+    request = %{
+      "contentLength" => metadata.content_length,
+      "contentType" => metadata.content_type,
+      "field" => field,
+      "observationId" => observation_id,
+      "sha256Hash" => metadata.sha2_56_hash,
+      "traceId" => trace_id
+    }
+
+    {_res, response} = LangfuseSdk.Generated.Media.media_get_upload_url(request)
+    Logger.info("Got upload URL: #{inspect(response)}")
+
+    if response["uploadUrl"] == nil do
+      "@@@langfuseMedia:type=#{metadata.content_type}|id=#{response["mediaId"]}|source=base64_data_uri@@@"
+    else
+      {_res, aws_response} =
+        [
+          url: response["uploadUrl"],
+          body: metadata.image_bytes,
+          retry: :transient,
+          headers: %{
+            "Content-Type" => metadata.content_type,
+            "x-amz-checksum-sha256" => metadata.sha2_56_hash
+          }
+        ]
+        |> Req.new()
+        |> Req.put()
+
+      Logger.info("Uploaded image: #{inspect(aws_response)}")
+
+      media_patch_request =
+        LangfuseSdk.Generated.Media.media_patch(response["mediaId"], %{
+          "uploadedAt" =>
+            DateTime.utc_now()
+            |> DateTime.to_iso8601(),
+          "uploadHttpStatus" => 200,
+          "uploadHttpError" => nil,
+          "uploadTimeMs" => nil
+        })
+
+      Logger.info("Patched media: #{inspect(media_patch_request)}")
+
+      "@@@langfuseMedia:type=#{metadata.content_type}|id=#{response["mediaId"]}|source=base64_data_uri@@@"
+    end
+  end
+end

--- a/lib/langfuse_sdk/support/media.ex
+++ b/lib/langfuse_sdk/support/media.ex
@@ -24,7 +24,6 @@ defmodule LangfuseSdk.Support.Media do
     Enum.map(content_list, &process_content_item(&1, generation_map, key))
   end
 
-  # EXPLICIT FIX HERE:
   defp process_content_item(%{"content" => content_entries} = content_item, generation_map, key)
        when is_list(content_entries) do
     updated_entries =

--- a/lib/langfuse_sdk/support/media.ex
+++ b/lib/langfuse_sdk/support/media.ex
@@ -26,14 +26,12 @@ defmodule LangfuseSdk.Support.Media do
 
   defp process_content_item(%{"content" => content} = content_item, generation_map, key)
        when is_list(content) do
-    update_in(content_item, ["content"], &process_content_entries(&1, generation_map, key))
+    update_in(content_item, ["content"], fn entries ->
+      Enum.map(entries, &process_entry(&1, generation_map, key))
+    end)
   end
 
   defp process_content_item(content_item, _generation_map, _key), do: content_item
-
-  defp process_content_entries(content_entries, generation_map, key) do
-    Enum.map(content_entries, &process_entry(&1, generation_map, key))
-  end
 
   defp process_entry(
          %{"type" => "image_url", "image_url" => %{"url" => url}} = entry,

--- a/lib/langfuse_sdk/support/media.ex
+++ b/lib/langfuse_sdk/support/media.ex
@@ -24,9 +24,12 @@ defmodule LangfuseSdk.Support.Media do
     Enum.map(content_list, &process_content_item(&1, generation_map, key))
   end
 
-  defp process_content_item(content_item, generation_map, key) do
+  defp process_content_item(%{"content" => content} = content_item, generation_map, key)
+       when is_list(content) do
     update_in(content_item, ["content"], &process_content_entries(&1, generation_map, key))
   end
+
+  defp process_content_item(content_item, _generation_map, _key), do: content_item
 
   defp process_content_entries(content_entries, generation_map, key) do
     Enum.map(content_entries, &process_entry(&1, generation_map, key))

--- a/openapi.yml
+++ b/openapi.yml
@@ -24,6 +24,568 @@ info:
     - Postman collection:
     https://cloud.langfuse.com/generated/postman/collection.json
 paths:
+  /api/public/annotation-queues:
+    get:
+      description: Get all annotation queues
+      operationId: annotationQueues_listQueues
+      tags:
+        - AnnotationQueues
+      parameters:
+        - name: page
+          in: query
+          description: page number, starts at 1
+          required: false
+          schema:
+            type: integer
+            nullable: true
+        - name: limit
+          in: query
+          description: limit of items per page
+          required: false
+          schema:
+            type: integer
+            nullable: true
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedAnnotationQueues'
+        '400':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '403':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '404':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '405':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+      security:
+        - BasicAuth: []
+  /api/public/annotation-queues/{queueId}:
+    get:
+      description: Get an annotation queue by ID
+      operationId: annotationQueues_getQueue
+      tags:
+        - AnnotationQueues
+      parameters:
+        - name: queueId
+          in: path
+          description: The unique identifier of the annotation queue
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AnnotationQueue'
+        '400':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '403':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '404':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '405':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+      security:
+        - BasicAuth: []
+  /api/public/annotation-queues/{queueId}/items:
+    get:
+      description: Get items for a specific annotation queue
+      operationId: annotationQueues_listQueueItems
+      tags:
+        - AnnotationQueues
+      parameters:
+        - name: queueId
+          in: path
+          description: The unique identifier of the annotation queue
+          required: true
+          schema:
+            type: string
+        - name: status
+          in: query
+          description: Filter by status
+          required: false
+          schema:
+            $ref: '#/components/schemas/AnnotationQueueStatus'
+            nullable: true
+        - name: page
+          in: query
+          description: page number, starts at 1
+          required: false
+          schema:
+            type: integer
+            nullable: true
+        - name: limit
+          in: query
+          description: limit of items per page
+          required: false
+          schema:
+            type: integer
+            nullable: true
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedAnnotationQueueItems'
+        '400':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '403':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '404':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '405':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+      security:
+        - BasicAuth: []
+    post:
+      description: Add an item to an annotation queue
+      operationId: annotationQueues_createQueueItem
+      tags:
+        - AnnotationQueues
+      parameters:
+        - name: queueId
+          in: path
+          description: The unique identifier of the annotation queue
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AnnotationQueueItem'
+        '400':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '403':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '404':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '405':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+      security:
+        - BasicAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateAnnotationQueueItemRequest'
+  /api/public/annotation-queues/{queueId}/items/{itemId}:
+    get:
+      description: Get a specific item from an annotation queue
+      operationId: annotationQueues_getQueueItem
+      tags:
+        - AnnotationQueues
+      parameters:
+        - name: queueId
+          in: path
+          description: The unique identifier of the annotation queue
+          required: true
+          schema:
+            type: string
+        - name: itemId
+          in: path
+          description: The unique identifier of the annotation queue item
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AnnotationQueueItem'
+        '400':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '403':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '404':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '405':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+      security:
+        - BasicAuth: []
+    patch:
+      description: Update an annotation queue item
+      operationId: annotationQueues_updateQueueItem
+      tags:
+        - AnnotationQueues
+      parameters:
+        - name: queueId
+          in: path
+          description: The unique identifier of the annotation queue
+          required: true
+          schema:
+            type: string
+        - name: itemId
+          in: path
+          description: The unique identifier of the annotation queue item
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AnnotationQueueItem'
+        '400':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '403':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '404':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '405':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+      security:
+        - BasicAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateAnnotationQueueItemRequest'
+    delete:
+      description: Remove an item from an annotation queue
+      operationId: annotationQueues_deleteQueueItem
+      tags:
+        - AnnotationQueues
+      parameters:
+        - name: queueId
+          in: path
+          description: The unique identifier of the annotation queue
+          required: true
+          schema:
+            type: string
+        - name: itemId
+          in: path
+          description: The unique identifier of the annotation queue item
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeleteAnnotationQueueItemResponse'
+        '400':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '403':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '404':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '405':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+      security:
+        - BasicAuth: []
+  /api/public/comments:
+    post:
+      description: >-
+        Create a comment. Comments may be attached to different object types
+        (trace, observation, session, prompt).
+      operationId: comments_create
+      tags:
+        - Comments
+      parameters: []
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateCommentResponse'
+        '400':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '403':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '404':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '405':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+      security:
+        - BasicAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateCommentRequest'
+    get:
+      description: Get all comments
+      operationId: comments_get
+      tags:
+        - Comments
+      parameters:
+        - name: page
+          in: query
+          description: Page number, starts at 1.
+          required: false
+          schema:
+            type: integer
+            nullable: true
+        - name: limit
+          in: query
+          description: >-
+            Limit of items per page. If you encounter api issues due to too
+            large page sizes, try to reduce the limit
+          required: false
+          schema:
+            type: integer
+            nullable: true
+        - name: objectType
+          in: query
+          description: >-
+            Filter comments by object type (trace, observation, session,
+            prompt).
+          required: false
+          schema:
+            type: string
+            nullable: true
+        - name: objectId
+          in: query
+          description: >-
+            Filter comments by object id. If objectType is not provided, an
+            error will be thrown.
+          required: false
+          schema:
+            type: string
+            nullable: true
+        - name: authorUserId
+          in: query
+          description: Filter comments by author user id.
+          required: false
+          schema:
+            type: string
+            nullable: true
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetCommentsResponse'
+        '400':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '403':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '404':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '405':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+      security:
+        - BasicAuth: []
+  /api/public/comments/{commentId}:
+    get:
+      description: Get a comment by id
+      operationId: comments_get-by-id
+      tags:
+        - Comments
+      parameters:
+        - name: commentId
+          in: path
+          description: The unique langfuse identifier of a comment
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Comment'
+        '400':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '403':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '404':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '405':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+      security:
+        - BasicAuth: []
   /api/public/dataset-items:
     post:
       description: Create a dataset item
@@ -162,6 +724,53 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DatasetItem'
+        '400':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '403':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '404':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '405':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+      security:
+        - BasicAuth: []
+    delete:
+      description: >-
+        Delete a dataset item and all its run items. This action is
+        irreversible.
+      operationId: datasetItems_delete
+      tags:
+        - DatasetItems
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeleteDatasetItemResponse'
         '400':
           description: ''
           content:
@@ -434,6 +1043,56 @@ paths:
               schema: {}
       security:
         - BasicAuth: []
+    delete:
+      description: Delete a dataset run and all its run items. This action is irreversible.
+      operationId: datasets_deleteRun
+      tags:
+        - Datasets
+      parameters:
+        - name: datasetName
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: runName
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeleteDatasetRunResponse'
+        '400':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '403':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '404':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '405':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+      security:
+        - BasicAuth: []
   /api/public/datasets/{datasetName}/runs:
     get:
       description: Get dataset runs
@@ -538,13 +1197,35 @@ paths:
   /api/public/ingestion:
     post:
       description: >-
-        Batched ingestion for Langfuse Tracing. If you want to use tracing via
-        the API, such as to build your own Langfuse client implementation, this
-        is the only API route you need to implement.
+        Batched ingestion for Langfuse Tracing.
+
+        If you want to use tracing via the API, such as to build your own
+        Langfuse client implementation, this is the only API route you need to
+        implement.
+
+
+        Within each batch, there can be multiple events.
+
+        Each event has a type, an id, a timestamp, metadata and a body.
+
+        Internally, we refer to this as the "event envelope" as it tells us
+        something about the event but not the trace.
+
+        We use the event id within this envelope to deduplicate messages to
+        avoid processing the same event twice, i.e. the event id should be
+        unique per request.
+
+        The event.body.id is the ID of the actual trace and will be used for
+        updates and will be visible within the Langfuse App.
+
+        I.e. if you want to update a trace, you'd use the same body id, but
+        separate event IDs.
 
 
         Notes:
 
+        - Introduction to data model:
+        https://langfuse.com/docs/tracing-data-model
 
         - Batch sizes are limited to 3.5 MB in total. You need to adjust the
         number of events per batch accordingly.
@@ -557,12 +1238,31 @@ paths:
         - Ingestion
       parameters: []
       responses:
-        '200':
+        '207':
           description: ''
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/IngestionResponse'
+              examples:
+                Example1:
+                  value:
+                    successes:
+                      - id: abcdef-1234-5678-90ab
+                        status: 201
+                    errors: []
+                Example2:
+                  value:
+                    successes:
+                      - id: abcdef-1234-5678-90ab
+                        status: 201
+                    errors: []
+                Example3:
+                  value:
+                    successes:
+                      - id: abcdef-1234-5678-90ab
+                        status: 201
+                    errors: []
         '400':
           description: ''
           content:
@@ -611,6 +1311,194 @@ paths:
                     debugging.
               required:
                 - batch
+            examples:
+              Example1:
+                value:
+                  batch:
+                    - id: abcdef-1234-5678-90ab
+                      timestamp: '2022-01-01T00:00:00.000Z'
+                      type: trace-create
+                      body:
+                        id: abcdef-1234-5678-90ab
+                        timestamp: '2022-01-01T00:00:00.000Z'
+                        environment: production
+                        name: My Trace
+                        userId: 1234-5678-90ab-cdef
+                        input: My input
+                        output: My output
+                        sessionId: 1234-5678-90ab-cdef
+                        release: 1.0.0
+                        version: 1.0.0
+                        metadata: My metadata
+                        tags:
+                          - tag1
+                          - tag2
+                        public: true
+              Example2:
+                value:
+                  batch:
+                    - id: abcdef-1234-5678-90ab
+                      timestamp: '2022-01-01T00:00:00.000Z'
+                      type: span-create
+                      body:
+                        id: abcdef-1234-5678-90ab
+                        traceId: 1234-5678-90ab-cdef
+                        startTime: '2022-01-01T00:00:00.000Z'
+                        environment: test
+              Example3:
+                value:
+                  batch:
+                    - id: abcdef-1234-5678-90ab
+                      timestamp: '2022-01-01T00:00:00.000Z'
+                      type: score-create
+                      body:
+                        id: abcdef-1234-5678-90ab
+                        traceId: 1234-5678-90ab-cdef
+                        name: My Score
+                        value: 0.9
+                        environment: default
+  /api/public/media/{mediaId}:
+    get:
+      description: Get a media record
+      operationId: media_get
+      tags:
+        - Media
+      parameters:
+        - name: mediaId
+          in: path
+          description: The unique langfuse identifier of a media record
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetMediaResponse'
+        '400':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '403':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '404':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '405':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+      security:
+        - BasicAuth: []
+    patch:
+      description: Patch a media record
+      operationId: media_patch
+      tags:
+        - Media
+      parameters:
+        - name: mediaId
+          in: path
+          description: The unique langfuse identifier of a media record
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: ''
+        '400':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '403':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '404':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '405':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+      security:
+        - BasicAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchMediaBody'
+  /api/public/media:
+    post:
+      description: Get a presigned upload URL for a media record
+      operationId: media_getUploadUrl
+      tags:
+        - Media
+      parameters: []
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetMediaUploadUrlResponse'
+        '400':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '403':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '404':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '405':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+      security:
+        - BasicAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GetMediaUploadUrlRequest'
   /api/public/metrics/daily:
     get:
       description: Get daily metrics of the Langfuse project
@@ -649,6 +1537,17 @@ paths:
         - name: tags
           in: query
           description: Optional filter for metrics where traces include all of these tags
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+              nullable: true
+        - name: environment
+          in: query
+          description: >-
+            Optional filter for metrics where events include any of these
+            environments
           required: false
           schema:
             type: array
@@ -1002,6 +1901,17 @@ paths:
           schema:
             type: string
             nullable: true
+        - name: environment
+          in: query
+          description: >-
+            Optional filter for observations where the environment is one of the
+            provided values.
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+              nullable: true
         - name: fromStartTime
           in: query
           description: >-
@@ -1104,6 +2014,76 @@ paths:
               schema: {}
       security:
         - BasicAuth: []
+  /api/public/v2/prompts/{name}/versions/{version}:
+    patch:
+      description: Update labels for a specific prompt version
+      operationId: promptVersion_update
+      tags:
+        - PromptVersion
+      parameters:
+        - name: name
+          in: path
+          description: The name of the prompt
+          required: true
+          schema:
+            type: string
+        - name: version
+          in: path
+          description: Version of the prompt to update
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Prompt'
+        '400':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '403':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '404':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '405':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+      security:
+        - BasicAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                newLabels:
+                  type: array
+                  items:
+                    type: string
+                  description: >-
+                    New labels for the prompt version. Labels are unique across
+                    versions. The "latest" label is reserved and managed by
+                    Langfuse.
+              required:
+                - newLabels
   /api/public/v2/prompts/{promptName}:
     get:
       description: Get a prompt
@@ -1561,6 +2541,17 @@ paths:
             type: string
             format: date-time
             nullable: true
+        - name: environment
+          in: query
+          description: >-
+            Optional filter for scores where the environment is one of the
+            provided values.
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+              nullable: true
         - name: source
           in: query
           description: Retrieve only scores from a specific source.
@@ -1597,6 +2588,13 @@ paths:
           schema:
             type: string
             nullable: true
+        - name: queueId
+          in: query
+          description: Retrieve only scores with a specific annotation queueId.
+          required: false
+          schema:
+            type: string
+            nullable: true
         - name: dataType
           in: query
           description: Retrieve only scores with a specific dataType.
@@ -1604,13 +2602,24 @@ paths:
           schema:
             $ref: '#/components/schemas/ScoreDataType'
             nullable: true
+        - name: traceTags
+          in: query
+          description: >-
+            Only scores linked to traces that include all of these tags will be
+            returned.
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+              nullable: true
       responses:
         '200':
           description: ''
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Scores'
+                $ref: '#/components/schemas/GetScoresResponse'
         '400':
           description: ''
           content:
@@ -1770,6 +2779,17 @@ paths:
             type: string
             format: date-time
             nullable: true
+        - name: environment
+          in: query
+          description: >-
+            Optional filter for sessions where the environment is one of the
+            provided values.
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+              nullable: true
       responses:
         '200':
           description: ''
@@ -1901,6 +2921,52 @@ paths:
               schema: {}
       security:
         - BasicAuth: []
+    delete:
+      description: Delete a specific trace
+      operationId: trace_delete
+      tags:
+        - Trace
+      parameters:
+        - name: traceId
+          in: path
+          description: The unique langfuse identifier of the trace to delete
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeleteTraceResponse'
+        '400':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '403':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '404':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '405':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+      security:
+        - BasicAuth: []
   /api/public/traces:
     get:
       description: Get list of traces
@@ -1995,6 +3061,17 @@ paths:
           schema:
             type: string
             nullable: true
+        - name: environment
+          in: query
+          description: >-
+            Optional filter for traces where the environment is one of the
+            provided values.
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+              nullable: true
       responses:
         '200':
           description: ''
@@ -2029,8 +3106,245 @@ paths:
               schema: {}
       security:
         - BasicAuth: []
+    delete:
+      description: Delete multiple traces
+      operationId: trace_deleteMultiple
+      tags:
+        - Trace
+      parameters: []
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeleteTraceResponse'
+        '400':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '401':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '403':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '404':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+        '405':
+          description: ''
+          content:
+            application/json:
+              schema: {}
+      security:
+        - BasicAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                traceIds:
+                  type: array
+                  items:
+                    type: string
+                  description: List of trace IDs to delete
+              required:
+                - traceIds
 components:
   schemas:
+    AnnotationQueueStatus:
+      title: AnnotationQueueStatus
+      type: string
+      enum:
+        - PENDING
+        - COMPLETED
+    AnnotationQueueObjectType:
+      title: AnnotationQueueObjectType
+      type: string
+      enum:
+        - TRACE
+        - OBSERVATION
+    AnnotationQueue:
+      title: AnnotationQueue
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+          nullable: true
+        scoreConfigIds:
+          type: array
+          items:
+            type: string
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - name
+        - scoreConfigIds
+        - createdAt
+        - updatedAt
+    AnnotationQueueItem:
+      title: AnnotationQueueItem
+      type: object
+      properties:
+        id:
+          type: string
+        queueId:
+          type: string
+        objectId:
+          type: string
+        objectType:
+          $ref: '#/components/schemas/AnnotationQueueObjectType'
+        status:
+          $ref: '#/components/schemas/AnnotationQueueStatus'
+        completedAt:
+          type: string
+          format: date-time
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - queueId
+        - objectId
+        - objectType
+        - status
+        - createdAt
+        - updatedAt
+    PaginatedAnnotationQueues:
+      title: PaginatedAnnotationQueues
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/AnnotationQueue'
+        meta:
+          $ref: '#/components/schemas/utilsMetaResponse'
+      required:
+        - data
+        - meta
+    PaginatedAnnotationQueueItems:
+      title: PaginatedAnnotationQueueItems
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/AnnotationQueueItem'
+        meta:
+          $ref: '#/components/schemas/utilsMetaResponse'
+      required:
+        - data
+        - meta
+    CreateAnnotationQueueItemRequest:
+      title: CreateAnnotationQueueItemRequest
+      type: object
+      properties:
+        objectId:
+          type: string
+        objectType:
+          $ref: '#/components/schemas/AnnotationQueueObjectType'
+        status:
+          $ref: '#/components/schemas/AnnotationQueueStatus'
+          nullable: true
+          description: Defaults to PENDING for new queue items
+      required:
+        - objectId
+        - objectType
+    UpdateAnnotationQueueItemRequest:
+      title: UpdateAnnotationQueueItemRequest
+      type: object
+      properties:
+        status:
+          $ref: '#/components/schemas/AnnotationQueueStatus'
+          nullable: true
+    DeleteAnnotationQueueItemResponse:
+      title: DeleteAnnotationQueueItemResponse
+      type: object
+      properties:
+        success:
+          type: boolean
+        message:
+          type: string
+      required:
+        - success
+        - message
+    CreateCommentRequest:
+      title: CreateCommentRequest
+      type: object
+      properties:
+        projectId:
+          type: string
+          description: The id of the project to attach the comment to.
+        objectType:
+          type: string
+          description: >-
+            The type of the object to attach the comment to (trace, observation,
+            session, prompt).
+        objectId:
+          type: string
+          description: >-
+            The id of the object to attach the comment to. If this does not
+            reference a valid existing object, an error will be thrown.
+        content:
+          type: string
+          description: >-
+            The content of the comment. May include markdown. Currently limited
+            to 3000 characters.
+        authorUserId:
+          type: string
+          nullable: true
+          description: The id of the user who created the comment.
+      required:
+        - projectId
+        - objectType
+        - objectId
+        - content
+    CreateCommentResponse:
+      title: CreateCommentResponse
+      type: object
+      properties:
+        id:
+          type: string
+          description: The id of the created object in Langfuse
+      required:
+        - id
+    GetCommentsResponse:
+      title: GetCommentsResponse
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/Comment'
+        meta:
+          $ref: '#/components/schemas/utilsMetaResponse'
+      required:
+        - data
+        - meta
     Trace:
       title: Trace
       type: object
@@ -2083,6 +3397,13 @@ components:
           type: boolean
           nullable: true
           description: Public traces are accessible via url without login
+        environment:
+          type: string
+          nullable: true
+          description: >-
+            The environment from which this trace originated. Can be any
+            lowercase alphanumeric string with hyphens and underscores that does
+            not start with 'langfuse'.
       required:
         - id
         - timestamp
@@ -2163,6 +3484,10 @@ components:
           format: date-time
         projectId:
           type: string
+        environment:
+          type: string
+          nullable: true
+          description: The environment from which this session originated.
       required:
         - id
         - createdAt
@@ -2237,7 +3562,9 @@ components:
         usage:
           $ref: '#/components/schemas/Usage'
           nullable: true
-          description: The usage data of the observation
+          description: >-
+            (Deprecated. Use usageDetails and costDetails instead.) The usage
+            data of the observation
         level:
           $ref: '#/components/schemas/ObservationLevel'
           description: The level of the observation
@@ -2253,6 +3580,32 @@ components:
           type: string
           nullable: true
           description: The prompt ID associated with the observation
+        usageDetails:
+          type: object
+          additionalProperties:
+            type: integer
+          nullable: true
+          description: >-
+            The usage details of the observation. Key is the name of the usage
+            metric, value is the number of units consumed. The total key is the
+            sum of all (non-total) usage metrics or the total value ingested.
+        costDetails:
+          type: object
+          additionalProperties:
+            type: number
+            format: double
+          nullable: true
+          description: >-
+            The cost details of the observation. Key is the name of the cost
+            metric, value is the cost in USD. The total key is the sum of all
+            (non-total) cost metrics or the total value ingested.
+        environment:
+          type: string
+          nullable: true
+          description: >-
+            The environment from which this observation originated. Can be any
+            lowercase alphanumeric string with hyphens and underscores that does
+            not start with 'langfuse'.
       required:
         - id
         - type
@@ -2293,17 +3646,23 @@ components:
           type: number
           format: double
           nullable: true
-          description: The calculated cost of the input in USD
+          description: >-
+            (Deprecated. Use usageDetails and costDetails instead.) The
+            calculated cost of the input in USD
         calculatedOutputCost:
           type: number
           format: double
           nullable: true
-          description: The calculated cost of the output in USD
+          description: >-
+            (Deprecated. Use usageDetails and costDetails instead.) The
+            calculated cost of the output in USD
         calculatedTotalCost:
           type: number
           format: double
           nullable: true
-          description: The calculated total cost in USD
+          description: >-
+            (Deprecated. Use usageDetails and costDetails instead.) The
+            calculated total cost in USD
         latency:
           type: number
           format: double
@@ -2319,7 +3678,9 @@ components:
     Usage:
       title: Usage
       type: object
-      description: Standard interface for usage and cost
+      description: >-
+        (Deprecated. Use usageDetails and costDetails instead.) Standard
+        interface for usage and cost
       properties:
         input:
           type: integer
@@ -2453,6 +3814,19 @@ components:
             Reference a score config on a score. When set, config and score name
             must be equal and value must comply to optionally defined numerical
             range
+        queueId:
+          type: string
+          nullable: true
+          description: >-
+            Reference an annotation queue on a score. Populated if the score was
+            initially created in an annotation queue.
+        environment:
+          type: string
+          nullable: true
+          description: >-
+            The environment from which this score originated. Can be any
+            lowercase alphanumeric string with hyphens and underscores that does
+            not start with 'langfuse'.
       required:
         - id
         - traceId
@@ -2558,6 +3932,37 @@ components:
       description: >-
         The value of the score. Must be passed as string for categorical scores,
         and numeric for boolean and numeric scores
+    Comment:
+      title: Comment
+      type: object
+      properties:
+        id:
+          type: string
+        projectId:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+        objectType:
+          $ref: '#/components/schemas/CommentObjectType'
+        objectId:
+          type: string
+        content:
+          type: string
+        authorUserId:
+          type: string
+          nullable: true
+      required:
+        - id
+        - projectId
+        - createdAt
+        - updatedAt
+        - objectType
+        - objectId
+        - content
     Dataset:
       title: Dataset
       type: object
@@ -2727,11 +4132,12 @@ components:
             to exact match, use `(?i)^modelname$`
         startDate:
           type: string
-          format: date
+          format: date-time
           nullable: true
           description: Apply only to generations which are newer than this ISO date.
         unit:
           $ref: '#/components/schemas/ModelUsageUnit'
+          nullable: true
           description: Unit used by this model.
         inputPrice:
           type: number
@@ -2767,7 +4173,6 @@ components:
         - id
         - modelName
         - matchPattern
-        - unit
         - isLangfuseManaged
     ModelUsageUnit:
       title: ModelUsageUnit
@@ -2801,6 +4206,14 @@ components:
           items:
             type: string
           nullable: true
+    CommentObjectType:
+      title: CommentObjectType
+      type: string
+      enum:
+        - TRACE
+        - OBSERVATION
+        - SESSION
+        - PROMPT
     DatasetStatus:
       title: DatasetStatus
       type: string
@@ -2821,6 +4234,15 @@ components:
         - NUMERIC
         - BOOLEAN
         - CATEGORICAL
+    DeleteDatasetItemResponse:
+      title: DeleteDatasetItemResponse
+      type: object
+      properties:
+        message:
+          type: string
+          description: Success message after deletion
+      required:
+        - message
     CreateDatasetItemRequest:
       title: CreateDatasetItemRequest
       type: object
@@ -2930,6 +4352,14 @@ components:
       required:
         - data
         - meta
+    DeleteDatasetRunResponse:
+      title: DeleteDatasetRunResponse
+      type: object
+      properties:
+        message:
+          type: string
+      required:
+        - message
     HealthResponse:
       title: HealthResponse
       type: object
@@ -3115,6 +4545,9 @@ components:
         version:
           type: string
           nullable: true
+        environment:
+          type: string
+          nullable: true
     CreateEventBody:
       title: CreateEventBody
       type: object
@@ -3173,6 +4606,15 @@ components:
         usage:
           $ref: '#/components/schemas/IngestionUsage'
           nullable: true
+        usageDetails:
+          $ref: '#/components/schemas/UsageDetails'
+          nullable: true
+        costDetails:
+          type: object
+          additionalProperties:
+            type: number
+            format: double
+          nullable: true
         promptName:
           type: string
           nullable: true
@@ -3202,6 +4644,15 @@ components:
           nullable: true
         promptName:
           type: string
+          nullable: true
+        usageDetails:
+          $ref: '#/components/schemas/UsageDetails'
+          nullable: true
+        costDetails:
+          type: object
+          additionalProperties:
+            type: number
+            format: double
           nullable: true
         promptVersion:
           type: integer
@@ -3264,6 +4715,9 @@ components:
         parentObservationId:
           type: string
           nullable: true
+        environment:
+          type: string
+          nullable: true
       required:
         - type
     TraceBody:
@@ -3303,6 +4757,9 @@ components:
           items:
             type: string
           nullable: true
+        environment:
+          type: string
+          nullable: true
         public:
           type: boolean
           nullable: true
@@ -3327,6 +4784,9 @@ components:
         name:
           type: string
           example: novelty
+        environment:
+          type: string
+          nullable: true
         value:
           $ref: '#/components/schemas/CreateScoreValue'
           description: >-
@@ -3520,6 +4980,197 @@ components:
       required:
         - successes
         - errors
+    OpenAICompletionUsageSchema:
+      title: OpenAICompletionUsageSchema
+      type: object
+      description: OpenAI Usage schema from (Chat-)Completion APIs
+      properties:
+        prompt_tokens:
+          type: integer
+        completion_tokens:
+          type: integer
+        total_tokens:
+          type: integer
+        prompt_tokens_details:
+          type: object
+          additionalProperties:
+            type: integer
+          nullable: true
+        completion_tokens_details:
+          type: object
+          additionalProperties:
+            type: integer
+          nullable: true
+      required:
+        - prompt_tokens
+        - completion_tokens
+        - total_tokens
+    OpenAIResponseUsageSchema:
+      title: OpenAIResponseUsageSchema
+      type: object
+      description: OpenAI Usage schema from Response API
+      properties:
+        input_tokens:
+          type: integer
+        output_tokens:
+          type: integer
+        total_tokens:
+          type: integer
+        input_tokens_details:
+          type: object
+          additionalProperties:
+            type: integer
+          nullable: true
+        output_tokens_details:
+          type: object
+          additionalProperties:
+            type: integer
+          nullable: true
+      required:
+        - input_tokens
+        - output_tokens
+        - total_tokens
+    UsageDetails:
+      title: UsageDetails
+      oneOf:
+        - type: object
+          additionalProperties:
+            type: integer
+        - $ref: '#/components/schemas/OpenAICompletionUsageSchema'
+        - $ref: '#/components/schemas/OpenAIResponseUsageSchema'
+    GetMediaResponse:
+      title: GetMediaResponse
+      type: object
+      properties:
+        mediaId:
+          type: string
+          description: The unique langfuse identifier of a media record
+        contentType:
+          type: string
+          description: The MIME type of the media record
+        contentLength:
+          type: integer
+          description: The size of the media record in bytes
+        uploadedAt:
+          type: string
+          format: date-time
+          description: The date and time when the media record was uploaded
+        url:
+          type: string
+          description: The download URL of the media record
+        urlExpiry:
+          type: string
+          description: The expiry date and time of the media record download URL
+      required:
+        - mediaId
+        - contentType
+        - contentLength
+        - uploadedAt
+        - url
+        - urlExpiry
+    PatchMediaBody:
+      title: PatchMediaBody
+      type: object
+      properties:
+        uploadedAt:
+          type: string
+          format: date-time
+          description: The date and time when the media record was uploaded
+        uploadHttpStatus:
+          type: integer
+          description: The HTTP status code of the upload
+        uploadHttpError:
+          type: string
+          nullable: true
+          description: The HTTP error message of the upload
+        uploadTimeMs:
+          type: integer
+          nullable: true
+          description: The time in milliseconds it took to upload the media record
+      required:
+        - uploadedAt
+        - uploadHttpStatus
+    GetMediaUploadUrlRequest:
+      title: GetMediaUploadUrlRequest
+      type: object
+      properties:
+        traceId:
+          type: string
+          description: The trace ID associated with the media record
+        observationId:
+          type: string
+          nullable: true
+          description: >-
+            The observation ID associated with the media record. If the media
+            record is associated directly with a trace, this will be null.
+        contentType:
+          $ref: '#/components/schemas/MediaContentType'
+        contentLength:
+          type: integer
+          description: The size of the media record in bytes
+        sha256Hash:
+          type: string
+          description: The SHA-256 hash of the media record
+        field:
+          type: string
+          description: >-
+            The trace / observation field the media record is associated with.
+            This can be one of `input`, `output`, `metadata`
+      required:
+        - traceId
+        - contentType
+        - contentLength
+        - sha256Hash
+        - field
+    GetMediaUploadUrlResponse:
+      title: GetMediaUploadUrlResponse
+      type: object
+      properties:
+        uploadUrl:
+          type: string
+          nullable: true
+          description: >-
+            The presigned upload URL. If the asset is already uploaded, this
+            will be null
+        mediaId:
+          type: string
+          description: The unique langfuse identifier of a media record
+      required:
+        - mediaId
+    MediaContentType:
+      title: MediaContentType
+      type: string
+      enum:
+        - image/png
+        - image/jpeg
+        - image/jpg
+        - image/webp
+        - image/gif
+        - image/svg+xml
+        - image/tiff
+        - image/bmp
+        - audio/mpeg
+        - audio/mp3
+        - audio/wav
+        - audio/ogg
+        - audio/oga
+        - audio/aac
+        - audio/mp4
+        - audio/flac
+        - video/mp4
+        - video/webm
+        - text/plain
+        - text/html
+        - text/css
+        - text/csv
+        - application/pdf
+        - application/msword
+        - application/vnd.ms-excel
+        - application/zip
+        - application/json
+        - application/xml
+        - application/octet-stream
+      description: The MIME type of the media record
     DailyMetrics:
       title: DailyMetrics
       type: object
@@ -3630,6 +5281,7 @@ components:
           description: Apply only to generations which are newer than this ISO date.
         unit:
           $ref: '#/components/schemas/ModelUsageUnit'
+          nullable: true
           description: Unit used by this model.
         inputPrice:
           type: number
@@ -3662,7 +5314,6 @@ components:
       required:
         - modelName
         - matchPattern
-        - unit
     Observations:
       title: Observations
       type: object
@@ -3804,6 +5455,10 @@ components:
             type: string
           nullable: true
           description: List of tags to apply to all versions of this prompt.
+        commitMessage:
+          type: string
+          nullable: true
+          description: Commit message for this prompt version.
       required:
         - name
         - prompt
@@ -3829,6 +5484,10 @@ components:
             type: string
           nullable: true
           description: List of tags to apply to all versions of this prompt.
+        commitMessage:
+          type: string
+          nullable: true
+          description: Commit message for this prompt version.
       required:
         - name
         - prompt
@@ -3878,6 +5537,17 @@ components:
           description: >-
             List of tags. Used to filter via UI and API. The same across
             versions of a prompt.
+        commitMessage:
+          type: string
+          nullable: true
+          description: Commit message for this prompt version.
+        resolutionGraph:
+          type: object
+          additionalProperties: true
+          nullable: true
+          description: >-
+            The dependency resolution graph for the current prompt. Null if
+            prompt has no dependencies.
       required:
         - name
         - version
@@ -3996,6 +5666,13 @@ components:
         comment:
           type: string
           nullable: true
+        environment:
+          type: string
+          nullable: true
+          description: >-
+            The environment of the score. Can be any lowercase alphanumeric
+            string with hyphens and underscores that does not start with
+            'langfuse'.
         dataType:
           $ref: '#/components/schemas/ScoreDataType'
           nullable: true
@@ -4023,14 +5700,98 @@ components:
           description: The id of the created object in Langfuse
       required:
         - id
-    Scores:
-      title: Scores
+    GetScoresResponseTraceData:
+      title: GetScoresResponseTraceData
+      type: object
+      properties:
+        userId:
+          type: string
+          nullable: true
+          description: The user ID associated with the trace referenced by score
+        tags:
+          type: array
+          items:
+            type: string
+          nullable: true
+          description: A list of tags associated with the trace referenced by score
+        environment:
+          type: string
+          nullable: true
+          description: The environment of the trace referenced by score
+    GetScoresResponseDataNumeric:
+      title: GetScoresResponseDataNumeric
+      type: object
+      properties:
+        trace:
+          $ref: '#/components/schemas/GetScoresResponseTraceData'
+      required:
+        - trace
+      allOf:
+        - $ref: '#/components/schemas/NumericScore'
+    GetScoresResponseDataCategorical:
+      title: GetScoresResponseDataCategorical
+      type: object
+      properties:
+        trace:
+          $ref: '#/components/schemas/GetScoresResponseTraceData'
+      required:
+        - trace
+      allOf:
+        - $ref: '#/components/schemas/CategoricalScore'
+    GetScoresResponseDataBoolean:
+      title: GetScoresResponseDataBoolean
+      type: object
+      properties:
+        trace:
+          $ref: '#/components/schemas/GetScoresResponseTraceData'
+      required:
+        - trace
+      allOf:
+        - $ref: '#/components/schemas/BooleanScore'
+    GetScoresResponseData:
+      title: GetScoresResponseData
+      oneOf:
+        - type: object
+          allOf:
+            - type: object
+              properties:
+                dataType:
+                  type: string
+                  enum:
+                    - NUMERIC
+            - $ref: '#/components/schemas/GetScoresResponseDataNumeric'
+          required:
+            - dataType
+        - type: object
+          allOf:
+            - type: object
+              properties:
+                dataType:
+                  type: string
+                  enum:
+                    - CATEGORICAL
+            - $ref: '#/components/schemas/GetScoresResponseDataCategorical'
+          required:
+            - dataType
+        - type: object
+          allOf:
+            - type: object
+              properties:
+                dataType:
+                  type: string
+                  enum:
+                    - BOOLEAN
+            - $ref: '#/components/schemas/GetScoresResponseDataBoolean'
+          required:
+            - dataType
+    GetScoresResponse:
+      title: GetScoresResponse
       type: object
       properties:
         data:
           type: array
           items:
-            $ref: '#/components/schemas/Score'
+            $ref: '#/components/schemas/GetScoresResponseData'
         meta:
           $ref: '#/components/schemas/utilsMetaResponse'
       required:
@@ -4062,6 +5823,14 @@ components:
       required:
         - data
         - meta
+    DeleteTraceResponse:
+      title: DeleteTraceResponse
+      type: object
+      properties:
+        message:
+          type: string
+      required:
+        - message
     Sort:
       title: Sort
       type: object


### PR DESCRIPTION
Adds image support to Langfuse generation using the API.

Example trace: https://langfuse.moon.workera.dev/project/cm28wxn31001ddmrnck70xswv/traces/fd746da6-29d3-48dd-bf04-9d76c68371e4?timestamp=2025-03-21T11%3A52%3A24.676Z&observation=b2db9af5-8a08-4277-b3a4-6b37d445be9a