### PR TITLE
chore: log request response in case of errors

### DIFF
--- a/lib/langfuse_sdk/support/client.ex
+++ b/lib/langfuse_sdk/support/client.ex
@@ -7,6 +7,8 @@ defmodule LangfuseSdk.Support.Client do
   alias LangfuseSdk.Support.Auth
   alias LangfuseSdk.Support.Translator
 
+  require Logger
+
   def request(opts) do
     case execute_request(opts) do
       {:ok, %{status: status, body: nil}} when status < 300 ->
@@ -20,11 +22,13 @@ defmodule LangfuseSdk.Support.Client do
       {:ok, %{body: %{"message" => message}}} ->
         {:error, message}
 
-      {:ok, %{status: status}} ->
+      {:ok, %{status: status} = response} ->
+        Logger.warning("Langfuse server responded with an error status: #{inspect(response)}")
         reason = "HTTP response status: #{inspect(status)}"
         {:error, reason}
 
-      {:error, %{reason: reason}} ->
+      {:error, %{reason: reason} = response} ->
+        Logger.warning("Langfuse server responded with an error status: #{inspect(response)}")
         {:error, reason}
     end
   end


### PR DESCRIPTION
Hey 👋 
i had a case where our AWS firewall was blocking a request for updating a trace due to the content of the prompt.

To figure this out I needed to cd into `langfuse_sdk` folder in my local deps and start adding `dbg` statements. I think it would be valuable to log the error when creating a trace, it would simplify debugging. wdyt?