### PR TITLE
Handle lists of ints in translator

### DIFF
--- a/lib/langfuse_sdk/support/translator.ex
+++ b/lib/langfuse_sdk/support/translator.ex
@@ -10,6 +10,7 @@ defmodule LangfuseSdk.Support.Translator do
   def translate(:boolean, body), do: body
   def translate(:integer, body) when is_binary(body), do: String.to_integer(body)
   def translate(:integer, body), do: body
+  def translate([:integer], body), do: body
   def translate({:string, :date_time}, body), do: NaiveDateTime.from_iso8601!(body)
 
   def translate({LangfuseSdk.Generated.TraceWithFullDetails, :t}, body), do: body

--- a/lib/langfuse_sdk/support/translator.ex
+++ b/lib/langfuse_sdk/support/translator.ex
@@ -10,8 +10,8 @@ defmodule LangfuseSdk.Support.Translator do
   def translate(:boolean, body), do: body
   def translate(:integer, body) when is_binary(body), do: String.to_integer(body)
   def translate(:integer, body), do: body
-  def translate([:integer], body), do: body
   def translate({:string, :date_time}, body), do: NaiveDateTime.from_iso8601!(body)
+  def translate([type], body), do: translate(type, body)
 
   def translate({LangfuseSdk.Generated.TraceWithFullDetails, :t}, body), do: body
 


### PR DESCRIPTION
Currently the fetching of prompts is broken due to lists of integers not being handled in the Translator.

### Steps to reproduce

```elixir
iex(1)> LangfuseSdk.Generated.Prompts.prompts_list
{{LangfuseSdk.Generated.PromptMetaListResponse, :t},
 %{
   "data" => [
     %{
       "labels" => ["latest", "production"],
       "lastConfig" => %{},
       "lastUpdatedAt" => "2025-07-20T15:52:47.269Z",
       "name" => "Drafter",
       "tags" => [],
       "versions" => [1] # causing the error
     }
   ],
   "meta" => %{"limit" => 10, "page" => 1, "totalItems" => 1, "totalPages" => 1},
   "pagination" => %{
     "limit" => 10,
     "page" => 1,
     "totalItems" => 1,
     "totalPages" => 1
   }
 }}
 ** (RuntimeError) Response translation not implemented: [:integer]
    (langfuse_sdk 0.0.1) lib/langfuse_sdk/support/translator.ex:43: LangfuseSdk.Support.Translator.translate/2
    (langfuse_sdk 0.0.1) lib/langfuse_sdk/support/translator.ex:36: anonymous fn/2 in LangfuseSdk.Support.Translator.translate/2
    (elixir 1.19.0-rc.0) lib/enum.ex:1688: Enum."-map/2-lists^map/1-1-"/2
    (elixir 1.19.0-rc.0) lib/enum.ex:1688: Enum."-map/2-lists^map/1-1-"/2
    (elixir 1.19.0-rc.0) lib/map.ex:267: Map.new_from_enum/2
    (langfuse_sdk 0.0.1) lib/langfuse_sdk/support/translator.ex:23: LangfuseSdk.Support.Translator.translate/2
    (elixir 1.19.0-rc.0) lib/enum.ex:1688: Enum."-map/2-lists^map/1-1-"/2
    (langfuse_sdk 0.0.1) lib/langfuse_sdk/support/translator.ex:31: anonymous fn/2 in LangfuseSdk.Support.Translator.translate/2
    (elixir 1.19.0-rc.0) lib/enum.ex:1688: Enum."-map/2-lists^map/1-1-"/2
    (elixir 1.19.0-rc.0) lib/map.ex:267: Map.new_from_enum/2
    (langfuse_sdk 0.0.1) lib/langfuse_sdk/support/translator.ex:23: LangfuseSdk.Support.Translator.translate/2
    (langfuse_sdk 0.0.1) lib/langfuse_sdk/support/client.ex:21: LangfuseSdk.Support.Client.request/1
    iex:1: (file)
```

### Schema with int lists

Integer lists on this schema causing the error 
https://github.com/workera-ai/langfuse_sdk/blob/041cf89326ff58e730526cb7c05834e181d4b4f5/lib/langfuse_sdk/generated/schemas/prompt_meta.ex#L28

### Fix 

Simple fix, just pass through lists of any type and unwrap with a recursive `translate`